### PR TITLE
fix: improve video handling in notes modal

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -167,10 +167,10 @@
         </div>
     </div>
     <!-- Load modules in order with cache busting -->
-    <script src="github.js?v=58"></script>
-    <script src="yahoo.js?v=58"></script>
-    <script src="portfolio.js?v=58"></script>
-    <script src="ui.js?v=58"></script>
-    <script src="main.js?v=58"></script>
+    <script src="github.js?v=59"></script>
+    <script src="yahoo.js?v=59"></script>
+    <script src="portfolio.js?v=59"></script>
+    <script src="ui.js?v=59"></script>
+    <script src="main.js?v=59"></script>
 </body>
 </html>

--- a/src/ui.js
+++ b/src/ui.js
@@ -402,7 +402,8 @@ function parseMedia(text) {
             </a>`;
         }
         if (isVideoUrl(trimmed)) {
-            return `<video src="${trimmed}" controls style="max-width:100%;height:auto;border-radius:8px;margin:8px 0;" preload="metadata"></video>`;
+            const escaped = trimmed.replace(/"/g, '&quot;');
+            return `<video src="${escaped}" controls playsinline style="max-width:100%;height:auto;border-radius:8px;margin:8px 0;" preload="metadata" onerror="this.outerHTML='\n<a href=&quot;${escaped}&quot; target=&quot;_blank&quot; rel=&quot;noopener noreferrer&quot; style=&quot;display:inline-block;margin:8px 0;color:#0066cc;&quot;>Open video ↗</a>\n'">Sorry, your browser cannot play this video. <a href="${escaped}" target="_blank" rel="noopener noreferrer">Open video ↗</a></video>`;
         }
         if (isImageUrl(trimmed)) {
             return `<img src="${trimmed}" style="max-width:100%; height:auto; border-radius:8px; margin:8px 0;" loading="lazy" />`;


### PR DESCRIPTION
Fixes the first unchecked item in #44 ("video's not playing correctly").

### What changed
- For direct video URLs in notes, render an inline video player as before
- Added robust fallback behavior: if playback fails (codec/CORS/hotlink restrictions), replace player with a clean **Open video ↗** link
- Kept serialization unchanged so original URL is preserved in notes

### Why
Some sources expose valid video URLs but fail inline playback depending on browser/domain restrictions. This avoids broken UX (blank/non-working player) and still gives one-click access.

Closes #44 (first sub-task).
