### PR TITLE
fix: normalize notes whitespace serialization

### DIFF
--- a/src/ui.js
+++ b/src/ui.js
@@ -411,6 +411,16 @@ function parseMedia(text) {
     }).join('\n');
 }
 
+function normalizeNotesWhitespace(text = '') {
+    return String(text)
+        .replace(/\r\n?/g, '\n')
+        .split('\n')
+        .map(line => line.replace(/[ \t]+$/g, ''))
+        .join('\n')
+        .replace(/\n{3,}/g, '\n\n')
+        .trim();
+}
+
 function serializeNotes(editorEl) {
     // Get the plain text, converting <img> and <iframe> back to URLs
     const clone = editorEl.cloneNode(true);
@@ -434,10 +444,9 @@ function serializeNotes(editorEl) {
     html = html.replace(/<br\s*\/?>/gi, '\n');
     // Keep spaces but decode HTML entities properly
     html = html.replace(/&nbsp;/g, ' ');
-    // Don't strip leading newlines - preserve formatting
     const decoder = document.createElement('textarea');
     decoder.innerHTML = html;
-    return decoder.value;
+    return normalizeNotesWhitespace(decoder.value);
 }
 
 /** Notes popup */


### PR DESCRIPTION
## Summary
Fixes whitespace/newline artifacts in saved notes by normalizing serialized text from the rich notes editor.

## Changes
- Added `normalizeNotesWhitespace()` in `src/ui.js`
- Trims trailing spaces on each line
- Converts CRLF to LF
- Collapses 3+ consecutive newlines to max 2
- Trims surrounding blank space before persisting

## Why
Issue #44 mentions a "whitespace newspace issue". The editor-to-text conversion could produce excessive blank lines and trailing spaces when saving notes.

Fixes #44
