### PR TITLE
fix: improve CORS failure messaging for market data

### DIFF
--- a/src/yahoo.js
+++ b/src/yahoo.js
@@ -23,6 +23,15 @@ function sleep(ms) {
     return new Promise(resolve => setTimeout(resolve, ms));
 }
 
+function normalizeFetchError(err) {
+    const msg = String(err?.message || err || 'Unknown error');
+    // Browser fetch often throws TypeError: Failed to fetch on CORS/network blocks.
+    if (/failed to fetch|networkerror|load failed/i.test(msg)) {
+        return new Error('Failed to fetch market data (likely CORS blocked). Enable CORS for this browser session and retry.');
+    }
+    return err instanceof Error ? err : new Error(msg);
+}
+
 async function fetchJsonDirect(url, label = 'request') {
     for (let attempt = 0; attempt < 3; attempt++) {
         try {
@@ -30,7 +39,8 @@ async function fetchJsonDirect(url, label = 'request') {
             mdLog(`${label} direct fetch`, { attempt: attempt + 1, status: res?.status, ok: !!res?.ok });
             if (!res?.ok) throw new Error(`HTTP ${res?.status ?? 'error'}`);
             return await res.json();
-        } catch (err) {
+        } catch (rawErr) {
+            const err = normalizeFetchError(rawErr);
             if (attempt < 2) {
                 const delayMs = 250 * (attempt + 1);
                 mdWarn(`${label} error, retrying`, { attempt: attempt + 1, delayMs, message: String(err?.message || err) });


### PR DESCRIPTION
## Summary
Improves the user-facing failure path when Yahoo Finance requests are blocked by browser CORS/network restrictions.

## Changes
- Added `normalizeFetchError()` in `src/yahoo.js`.
- Detects common browser fetch failure signatures (`Failed to fetch`, `NetworkError`, `Load failed`).
- Replaces opaque errors with an actionable message: enable CORS for this browser session and retry.

## Why
Issue #44 explicitly calls out CORS friction. This change makes failures self-diagnosing instead of silent/ambiguous.

Refs #44
