### PR TITLE
feat: fill all empty stock notes with contrarian LLM-style theses

### DIFF
--- a/portfolio.html
+++ b/portfolio.html
@@ -1,10 +1,11 @@
 <!DOCTYPE html>
-<html lang="en"><head><meta charset="UTF-8"><title>Portfolio</title>
+
+<html lang="en"><head><meta charset="utf-8"/><title>Portfolio</title>
 <style>body{font-family:Arial,sans-serif;margin:2em}table{border-collapse:collapse;width:100%}th,td{border:1px solid #ccc;padding:8px;text-align:left}th{background:#f4f4f4}.star{color:gold;font-size:1.2em}.notes-cell{white-space:pre-wrap}</style>
 </head><body><h1>Portfolio</h1><p><em>Last updated: 2026-03-22T09:47:56.284Z</em></p>
-<table data-label-order='[]'><thead><tr><th>Ticker</th><th>Name</th><th>Date</th><th>Labels</th><th>Notes</th><th>Rating</th></tr></thead>
+<table data-label-order="[]"><thead><tr><th>Ticker</th><th>Name</th><th>Date</th><th>Labels</th><th>Notes</th><th>Rating</th></tr></thead>
 <tbody>
-      <tr><td>TSLA</td><td>Tesla, Inc.</td><td>2024-06-01</td><td>ai, robotics, energy</td><td class="notes-cell">FY25 income statement - 20% gross margin - 6% operating margin - 3% net margin profit
+<tr><td>TSLA</td><td>Tesla, Inc.</td><td>2024-06-01</td><td>ai, robotics, energy</td><td class="notes-cell">FY25 income statement - 20% gross margin - 6% operating margin - 3% net margin profit
 = WEAK, though not weakest for industry
 
 PE ratio of 300
@@ -22,16 +23,16 @@ This is an abundance play. Dominating company in the post capitalistic era of au
 Short term catalyst: robotaxi rollout very likely and agressive in 2026
 
 Accumulation phase</td><td><span class="star">★★★★★</span> (5)</td></tr>
-      <tr><td>TWST</td><td></td><td>2025-07-01</td><td>genetics</td><td class="notes-cell">very cool tech, users report some of the cheapest on the market for high quality
+<tr><td>TWST</td><td></td><td>2025-07-01</td><td>genetics</td><td class="notes-cell">very cool tech, users report some of the cheapest on the market for high quality
 But business model viability is a question</td><td><span class="star">★★★☆☆</span> (3)</td></tr>
-      <tr><td>XPEV</td><td>XPeng Inc.</td><td>2024-08-01</td><td>ai, robotics</td><td class="notes-cell">Biggest tesla contender
+<tr><td>XPEV</td><td>XPeng Inc.</td><td>2024-08-01</td><td>ai, robotics</td><td class="notes-cell">Biggest tesla contender
 vision based AI
 humanoid development
 vertically integrated, working on their own chips.
 
 Basically the Tesla abundance thesis with diversification from the musk brand</td><td><span class="star">★★★★★</span> (5)</td></tr>
-      <tr><td>SIDU</td><td>Sidus Space, Inc.</td><td>2025-07-29</td><td>space</td><td class="notes-cell">shitty ceo, just riding the space bull</td><td><span class="star">☆☆☆☆☆</span> (0)</td></tr>
-      <tr><td>NBIS</td><td>Nebius Group N.V.</td><td>2025-04-01</td><td>ai</td><td class="notes-cell">coolest ceo Arkady Volozh
+<tr><td>SIDU</td><td>Sidus Space, Inc.</td><td>2025-07-29</td><td>space</td><td class="notes-cell">shitty ceo, just riding the space bull</td><td><span class="star">☆☆☆☆☆</span> (0)</td></tr>
+<tr><td>NBIS</td><td>Nebius Group N.V.</td><td>2025-04-01</td><td>ai</td><td class="notes-cell">coolest ceo Arkady Volozh
 - main assets are engineers and datacenters
 https://www.youtube.com/watch?v=8qvAZutaDHs     
 
@@ -39,7 +40,7 @@ GROWING
 https://static.seekingalpha.com/uploads/2025/6/28/54097509-17511278852583811_origin.png     
 
 Main risk: space based compute</td><td><span class="star">★★★☆☆</span> (3)</td></tr>
-      <tr><td>GOOG</td><td>Alphabet Inc.</td><td>2025-01-01</td><td>ai</td><td class="notes-cell">https://substackcdn.com/image/fetch/$s_!Jivn!,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F172af89a-7578-4882-83a8-962644d112e2_2745x1543.png       
+<tr><td>GOOG</td><td>Alphabet Inc.</td><td>2025-01-01</td><td>ai</td><td class="notes-cell">https://substackcdn.com/image/fetch/$s_!Jivn!,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F172af89a-7578-4882-83a8-962644d112e2_2745x1543.png       
 
 search dependent business model but
 - CRAZY net profit margin of 29%
@@ -53,7 +54,7 @@ search dependent business model but
 - waymo looks compromised, stalled progress
 
 But a 15% stake in Antropic (claude opus !) and 7% stake in Spacex !!</td><td><span class="star">★★★☆☆</span> (3)</td></tr>
-      <tr><td>AMZN</td><td>Amazon.com, Inc.</td><td>2025-01-01</td><td>ai, robotics</td><td class="notes-cell">https://pbs.twimg.com/media/GxNlyCWakAACkvg.jpg
+<tr><td>AMZN</td><td>Amazon.com, Inc.</td><td>2025-01-01</td><td>ai, robotics</td><td class="notes-cell">https://pbs.twimg.com/media/GxNlyCWakAACkvg.jpg
 
 
 - quite diversified
@@ -63,13 +64,13 @@ But a 15% stake in Antropic (claude opus !) and 7% stake in Spacex !!</td><td><s
 - building trainium and inferentia for more vertical integration
 = very future proof company
 market doesn't like the capex</td><td><span class="star">★★★☆☆</span> (3)</td></tr>
-      <tr><td>LMND</td><td>Lemonade, Inc.</td><td>2025-07-01</td><td>insurance</td><td class="notes-cell">Thesis: by cutting out agents and brick and mortar costs and using AI they will be able to deliver a necessary evil (insurance) at a lower cost at scale -&gt; bring down those premiums, claims paid / premium earned = loss ratio is often around 50% nowadays !
+<tr><td>LMND</td><td>Lemonade, Inc.</td><td>2025-07-01</td><td>insurance</td><td class="notes-cell">Thesis: by cutting out agents and brick and mortar costs and using AI they will be able to deliver a necessary evil (insurance) at a lower cost at scale -&gt; bring down those premiums, claims paid / premium earned = loss ratio is often around 50% nowadays !
 
 Bottlenecks:
 - customer acquisition
 - ai reliability
 - scaling</td><td><span class="star">★★★☆☆</span> (3)</td></tr>
-      <tr><td>AMD</td><td>Advanced Micro Devices, Inc.</td><td>2025-01-01</td><td>ai</td><td class="notes-cell">https://pbs.twimg.com/media/GqS0V66bAAMtNGL.jpg       The main problem for AMD is CUDA and legacy. People learned cuda and invested in huge datacenters with nvidia and don't want to switch.
+<tr><td>AMD</td><td>Advanced Micro Devices, Inc.</td><td>2025-01-01</td><td>ai</td><td class="notes-cell">https://pbs.twimg.com/media/GqS0V66bAAMtNGL.jpg       The main problem for AMD is CUDA and legacy. People learned cuda and invested in huge datacenters with nvidia and don't want to switch.
 So the thesis becomes, as AI starts writing more of the software (including cuda kernels) and new datacenters are being built everywhere, does this moat remain ? post Claude Opus ?
 
 Growing revenue but stalling profit because trying to catch up with nvidia:
@@ -78,11 +79,11 @@ https://substackcdn.com/image/fetch/$s_!BBXE!,w_1456,c_limit,f_webp,q_auto:good,
 
 Risk:
 - Fabless -&gt; bad bad bad</td><td><span class="star">★★★☆☆</span> (3)</td></tr>
-      <tr><td>INTC</td><td>Intel Corporation</td><td>2026-02-01</td><td>ai</td><td class="notes-cell">loosing technology, investment by us government and restructuring but for now no sign of revival</td><td><span class="star">★★☆☆☆</span> (2)</td></tr>
-      <tr><td>IREN</td><td>IREN LIMITED</td><td>2025-08-01</td><td>ai</td><td class="notes-cell">Super speculative AI infra player
+<tr><td>INTC</td><td>Intel Corporation</td><td>2026-02-01</td><td>ai</td><td class="notes-cell">loosing technology, investment by us government and restructuring but for now no sign of revival</td><td><span class="star">★★☆☆☆</span> (2)</td></tr>
+<tr><td>IREN</td><td>IREN LIMITED</td><td>2025-08-01</td><td>ai</td><td class="notes-cell">Super speculative AI infra player
 vs Nebius
 Space based compute ?</td><td><span class="star">★★★☆☆</span> (3)</td></tr>
-      <tr><td>MU</td><td>Micron Technology, Inc.</td><td>2025-08-01</td><td>ai</td><td class="notes-cell">Very nice margins
+<tr><td>MU</td><td>Micron Technology, Inc.</td><td>2025-08-01</td><td>ai</td><td class="notes-cell">Very nice margins
 Dropped crucial brand to focus on b2b
 
 https://substackcdn.com/image/fetch/$s_!zn7a!,f_auto,q_auto:good,fl_progressive:steep/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2Fca046a1f-5b73-49b8-a856-ca470266ba99_2740x1539.png          
@@ -97,7 +98,7 @@ Very sensitive to
 
 But as AI is showing no sign of slowing down, will this continue ? and for how long ? it depends on the speed of building factories compared to the growing needs in memory of AI
 Will AI growth correlate to a growth in memory needs or will smart AI compression techniques mitigate this ?</td><td><span class="star">★★★☆☆</span> (3)</td></tr>
-      <tr><td>AVGO</td><td>Broadcom Inc.</td><td>2025-06-01</td><td>ai</td><td class="notes-cell">The silent AI winner  - networking chips essential for AI datacenters
+<tr><td>AVGO</td><td>Broadcom Inc.</td><td>2025-06-01</td><td>ai</td><td class="notes-cell">The silent AI winner  - networking chips essential for AI datacenters
 - custom AI chips (TPU for Google, etc)
 - VMware acquisition = enterprise software cash cow
 - 50%+ gross margins, insane FCF generation
@@ -108,7 +109,7 @@ https://pbs.twimg.com/media/G76w_xDboAAiMN5.jpg
 
 But is fabless !!
 but they do manufacture their own wifi chips, internet routers, ...</td><td><span class="star">★☆☆☆☆</span> (1)</td></tr>
-      <tr><td>OKLO</td><td>Oklo Inc.</td><td>2026-02-01</td><td>energy</td><td class="notes-cell">Sam Altman's nuclear baby
+<tr><td>OKLO</td><td>Oklo Inc.</td><td>2026-02-01</td><td>energy</td><td class="notes-cell">Sam Altman's nuclear baby
 - small modular fission reactors
 - fuel recycling angle is interesting
 - zero revenue, all promises
@@ -117,8 +118,8 @@ but they do manufacture their own wifi chips, internet routers, ...</td><td><spa
 Pure speculation on nuclear renaissance for AI datacenters.
 Cool tech but years away from any real business. Altman halo effect priced in.
 Competing with SMR/NuScale who are further along but also struggling.</td><td><span class="star">☆☆☆☆☆</span> (0)</td></tr>
-      <tr><td>SMR</td><td>NuScale Power Corporation</td><td>2026-02-01</td><td>energy</td><td class="notes-cell">zero charism ceo</td><td><span class="star">☆☆☆☆☆</span> (0)</td></tr>
-      <tr><td>ASML</td><td>ASML Holding N.V. - New York Re</td><td>2026-02-01</td><td>ai</td><td class="notes-cell">Building the machines to build the machines that power AI. As long as companies are planning to increase CAPEX in AI this will boom
+<tr><td>SMR</td><td>NuScale Power Corporation</td><td>2026-02-01</td><td>energy</td><td class="notes-cell">zero charism ceo</td><td><span class="star">☆☆☆☆☆</span> (0)</td></tr>
+<tr><td>ASML</td><td>ASML Holding N.V. - New York Re</td><td>2026-02-01</td><td>ai</td><td class="notes-cell">Building the machines to build the machines that power AI. As long as companies are planning to increase CAPEX in AI this will boom
 
 Risks:
 Capex expenditure dependent like Nvidia. Deepseek moments, intelligence/compute is supposed to be still way to high by orders of magnitude and model architecture improvements could decrease this and lead to infra winter
@@ -126,10 +127,10 @@ Capex expenditure dependent like Nvidia. Deepseek moments, intelligence/compute 
 https://pbs.twimg.com/media/G_vFQqobAAAsOhH.jpg       
 
 A possible hedge play against Nvidia, as AMD and others catch up and eat away the profit margins, profit margins of the total supply chain might shift to ASML. As long as china does not catch up...</td><td><span class="star">★★★☆☆</span> (3)</td></tr>
-      <tr><td>RKLB</td><td>Rocket Lab Corporation</td><td>2025-04-01</td><td>space</td><td class="notes-cell">Biggest Spacex competitor
+<tr><td>RKLB</td><td>Rocket Lab Corporation</td><td>2025-04-01</td><td>space</td><td class="notes-cell">Biggest Spacex competitor
 Filling the small rocket gap. Spacex focuses on heavy lift while RKLB on small-to-medium payload launches and end-to-end space systems, offering a more tailored, agile service for smaller, dedicated satellite deployments
 = The "Bus vs. Uber" Problem</td><td><span class="star">★★★☆☆</span> (3)</td></tr>
-      <tr><td>HYMLF</td><td>Hyundai Motor Company</td><td>2026-02-01</td><td>robotics</td><td class="notes-cell">Korean auto giant going all-in on future
+<tr><td>HYMLF</td><td>Hyundai Motor Company</td><td>2026-02-01</td><td>robotics</td><td class="notes-cell">Korean auto giant going all-in on future
 - owns Boston Dynamics (robots!)
 - solid EV lineup with Ioniq
 - hydrogen fuel cell leader
@@ -138,23 +139,23 @@ Filling the small rocket gap. Spacex focuses on heavy lift while RKLB on small-t
 Boston Dynamics is cool but still burning money.
 EV competition from China is brutal.
 Might be a sleeper robotics play through BD ownership. OTK market doesn't price this in.</td><td><span class="star">★☆☆☆☆</span> (1)</td></tr>
-      <tr><td>3750.HK</td><td>CATL</td><td>2025-11-01</td><td>battery</td><td class="notes-cell">World's biggest EV battery maker
+<tr><td>3750.HK</td><td>CATL</td><td>2025-11-01</td><td>battery</td><td class="notes-cell">World's biggest EV battery maker
 - 35%+ global market share
 - supplies Tesla, BMW, everyone basically
-- sodium-ion and solid state R&D
+- sodium-ion and solid state R&amp;D
 - integrating into energy storage
 
 Chinese company = geopolitical risk, potential US restrictions
 BUT undeniable tech and scale leadership. Margins getting squeezed by competition.
 If you believe in EVs at scale, hard to avoid CATL.
 </td><td><span class="star">★☆☆☆☆</span> (1)</td></tr>
-      <tr><td>SATL</td><td>Satellogic Inc.</td><td>2026-02-01</td><td>space</td><td class="notes-cell">Very cool ceo
+<tr><td>SATL</td><td>Satellogic Inc.</td><td>2026-02-01</td><td>space</td><td class="notes-cell">Very cool ceo
 recent ipo but company has been existing for a while</td><td><span class="star">★★☆☆☆</span> (2)</td></tr>
-      <tr><td>USAR</td><td>USA Rare Earth, Inc.</td><td>2026-02-01</td><td>mining</td><td class="notes-cell">US independence play on rare earth supply chain
+<tr><td>USAR</td><td>USA Rare Earth, Inc.</td><td>2026-02-01</td><td>mining</td><td class="notes-cell">US independence play on rare earth supply chain
 Very geopolitics dependent
 Recent boom due to decisions without much underlying tech or progress
 Too risky, but watch out</td><td><span class="star">★★☆☆☆</span> (2)</td></tr>
-      <tr><td>ENVX</td><td>Enovix Corporation</td><td>2026-02-02</td><td>battery</td><td class="notes-cell">Silicon anode battery tech
+<tr><td>ENVX</td><td>Enovix Corporation</td><td>2026-02-02</td><td>battery</td><td class="notes-cell">Silicon anode battery tech
 - higher energy density than traditional lithium-ion
 - targeting consumer electronics first, then EVs
 - actually shipping product now (finally)
@@ -163,7 +164,7 @@ Too risky, but watch out</td><td><span class="star">★★☆☆☆</span> (2)</
 Lots of battery startups have died promising next-gen tech.
 This one seems further along but still proving manufacturing at scale.
 High risk/reward. Could be QuantumScape 2.0 or actually work.</td><td><span class="star">★☆☆☆☆</span> (1)</td></tr>
-      <tr><td>ETN</td><td>Eaton Corporation, PLC</td><td>2026-02-02</td><td>energy</td><td class="notes-cell">Electrical infrastructure boring money machine
+<tr><td>ETN</td><td>Eaton Corporation, PLC</td><td>2026-02-02</td><td>energy</td><td class="notes-cell">Electrical infrastructure boring money machine
 - power management, grid solutions
 - datacenter power = indirect AI play
 - 20%+ operating margins
@@ -174,7 +175,7 @@ Valuation has run up a lot on AI datacenter hype.
 Quality industrial compounder. Your dad's stock pick.
 
 Boring ceo</td><td><span class="star">☆☆☆☆☆</span> (0)</td></tr>
-      <tr><td>GEV</td><td>GE Vernova Inc.</td><td>2026-02-02</td><td>energy</td><td class="notes-cell">GE's energy spinoff
+<tr><td>GEV</td><td>GE Vernova Inc.</td><td>2026-02-02</td><td>energy</td><td class="notes-cell">GE's energy spinoff
 - gas turbines, wind, grid solutions
 - huge installed base = service revenue
 - wind business has been problematic (offshore losses)
@@ -183,7 +184,7 @@ Boring ceo</td><td><span class="star">☆☆☆☆☆</span> (0)</td></tr>
 Grid modernization play. Messy business mix.
 Onshore wind ok, offshore wind = money pit.
 Bet on gas turbines for datacenter backup power. Ironic green energy company powered by gas.</td><td><span class="star">☆☆☆☆☆</span> (0)</td></tr>
-      <tr><td>NVT</td><td>nVent Electric plc</td><td>2026-02-02</td><td>energy</td><td class="notes-cell">Electrical enclosures and thermal management
+<tr><td>NVT</td><td>nVent Electric plc</td><td>2026-02-02</td><td>energy</td><td class="notes-cell">Electrical enclosures and thermal management
 - cooling solutions for datacenters = AI angle
 - liquid cooling tech acquisition
 - boring industrial products, steady margins
@@ -192,7 +193,7 @@ Nobody knows this company exists which might be good.
 Picks and shovels play for datacenter buildout.
 Smaller than Vertiv, less coverage, potentially less priced in.
 Niche but could benefit from liquid cooling trend for AI chips.</td><td><span class="star">☆☆☆☆☆</span> (0)</td></tr>
-      <tr><td>VRT</td><td>Vertiv Holdings, LLC</td><td>2026-02-02</td><td>ai, energy</td><td class="notes-cell">Datacenter cooling and power infrastructure
+<tr><td>VRT</td><td>Vertiv Holdings, LLC</td><td>2026-02-02</td><td>ai, energy</td><td class="notes-cell">Datacenter cooling and power infrastructure
 - liquid cooling for AI chips is their moment
 - backlog growing like crazy
 - margins expanding
@@ -202,14 +203,14 @@ Stock has gone parabolic on AI hype.
 Legit business but valuation assumes flawless execution.
 If AI capex slows, this gets crushed.
 Pure AI infrastructure pick without the semiconductor complexity.</td><td><span class="star">★★☆☆☆</span> (2)</td></tr>
-      <tr><td>ONDS</td><td>Ondas Inc</td><td>2026-02-03</td><td>defense</td><td class="notes-cell">Highly speculative quasi meme stock hyped on social media very aggressively diluting their shareholders
+<tr><td>ONDS</td><td>Ondas Inc</td><td>2026-02-03</td><td>defense</td><td class="notes-cell">Highly speculative quasi meme stock hyped on social media very aggressively diluting their shareholders
 But with some interesting fundamentals, strong cash position
 
 https://static.seekingalpha.com/uploads/2025/11/5/59261277-17623500613317227.png  
 and on the drone dominance program...
 
 Keep an eye on it</td><td><span class="star">★★★☆☆</span> (3)</td></tr>
-      <tr><td>NET</td><td>Cloudflare, Inc.</td><td>2026-02-04</td><td></td><td class="notes-cell">Thesis: Edge security + developer platform compounding with enterprise upsell.
+<tr><td>NET</td><td>Cloudflare, Inc.</td><td>2026-02-04</td><td></td><td class="notes-cell">Thesis: Edge security + developer platform compounding with enterprise upsell.
 Market pricing in: sustained high growth + operating leverage.
 Catalysts: AI traffic demand, SASE expansion, Workers adoption.
 Moat/Risks: global network moat; risk = hyperscaler competition + pricing pressure.
@@ -219,7 +220,7 @@ Red flags: slowing large-customer adds, margin compression, rising churn.
 Checkpoints: (1) NRR trend, (2) operating margin expansion, (3) AI inference traffic monetization.
 Verdict: Watch / quality compounder if execution remains clean.
 What could break thesis: growth decelerates faster than margin expansion.</td><td><span class="star">★☆☆☆☆</span> (1)</td></tr>
-      <tr><td>RDW</td><td>Redwire Corp</td><td>2026-02-04</td><td></td><td class="notes-cell">Thesis: Space infrastructure/defense exposure with optionality from in-space manufacturing.
+<tr><td>RDW</td><td>Redwire Corp</td><td>2026-02-04</td><td></td><td class="notes-cell">Thesis: Space infrastructure/defense exposure with optionality from in-space manufacturing.
 Market pricing in: contract wins + scaling from niche supplier to strategic platform.
 Catalysts: U.S. defense/space budget flow, major program awards, production scale-up.
 Moat/Risks: mission expertise; risk = execution delays, customer concentration, funding cycles.
@@ -229,7 +230,7 @@ Red flags: persistent burn without margin improvement, delayed milestones.
 Checkpoints: (1) backlog growth quality, (2) margin trajectory, (3) dilution control.
 Verdict: Speculative Watch.
 What could break thesis: program slips + capital raises at weak terms.</td><td><span class="star">☆☆☆☆☆</span> (0)</td></tr>
-      <tr><td>ORR</td><td>Militia Long/Short Equity ETF</td><td>2026-02-05</td><td></td><td class="notes-cell">Thesis: Long/short equity ETF wrapper; outcome depends on manager process, not one business moat.
+<tr><td>ORR</td><td>Militia Long/Short Equity ETF</td><td>2026-02-05</td><td></td><td class="notes-cell">Thesis: Long/short equity ETF wrapper; outcome depends on manager process, not one business moat.
 Market pricing in: manager alpha persistence + risk control.
 Catalysts: rolling alpha vs benchmark, drawdown profile, fee competitiveness.
 Moat/Risks: process/discipline; risk = style drift, crowding, fee drag.
@@ -239,19 +240,19 @@ Red flags: sustained underperformance net of fees, unstable exposures.
 Checkpoints: (1) 1y/3y alpha, (2) max drawdown, (3) consistency of factor exposures.
 Verdict: Only hold if proven net alpha.
 What could break thesis: alpha disappears when regime changes.</td><td><span class="star">★★★☆☆</span> (3)</td></tr>
-      <tr><td>UBTRF</td><td>UBTECH ROBOTICS CORP LTD</td><td>2025-04-01</td><td>ai</td><td class="notes-cell">Thesis: Humanoid/service robotics optionality leveraged to China automation trend.
+<tr><td>UBTRF</td><td>UBTECH ROBOTICS CORP LTD</td><td>2025-04-01</td><td>ai</td><td class="notes-cell">Thesis: Humanoid/service robotics optionality leveraged to China automation trend.
 Market pricing in: commercialization beyond demos into repeatable deployments.
 Catalysts: enterprise contracts, unit economics improvement, ecosystem partnerships.
 Moat/Risks: hardware+software integration; risk = intense competition + hardware margin pressure.
-Financial quality: monitor revenue quality, gross margin, R&D intensity, cash runway.
+Financial quality: monitor revenue quality, gross margin, R&amp;D intensity, cash runway.
 Valuation sanity: pre-profit uncertainty high; focus on execution milestones.
 Red flags: promo-heavy narrative without shipment/usage proof.
 Checkpoints: (1) paid deployments, (2) gross margin trend, (3) recurring software/service revenue.
 Verdict: High-risk speculative.
 What could break thesis: demand remains pilot-only.</td><td><span class="star">★★☆☆☆</span> (2)</td></tr>
-      <tr><td>UBER</td><td>Uber Technologies, Inc.</td><td>2026-02-19</td><td></td><td class="notes-cell">short it</td><td><span class="star">☆☆☆☆☆</span> (0)</td></tr>
-      <tr><td>CVNA</td><td>Carvana Co.</td><td>2026-02-19</td><td></td><td class="notes-cell">short it</td><td><span class="star">☆☆☆☆☆</span> (0)</td></tr>
-      <tr><td>RPI.L</td><td>RASPBERRY PI HOLDINGS PLC ORD 0</td><td>2026-02-22</td><td></td><td class="notes-cell">Thesis: Low-cost compute ecosystem (education + embedded/industrial) with strong developer community.
+<tr><td>UBER</td><td>Uber Technologies, Inc.</td><td>2026-02-19</td><td></td><td class="notes-cell">short it</td><td><span class="star">☆☆☆☆☆</span> (0)</td></tr>
+<tr><td>CVNA</td><td>Carvana Co.</td><td>2026-02-19</td><td></td><td class="notes-cell">short it</td><td><span class="star">☆☆☆☆☆</span> (0)</td></tr>
+<tr><td>RPI.L</td><td>RASPBERRY PI HOLDINGS PLC ORD 0</td><td>2026-02-22</td><td></td><td class="notes-cell">Thesis: Low-cost compute ecosystem (education + embedded/industrial) with strong developer community.
 Market pricing in: durable demand outside hobby cycles.
 Catalysts: industrial design wins, supply normalization, software ecosystem expansion.
 Moat/Risks: ecosystem + brand; risk = commoditized SBC hardware and cyclic inventory swings.
@@ -261,7 +262,7 @@ Red flags: inventory build, weak industrial mix, ASP pressure.
 Checkpoints: (1) industrial share growth, (2) margin resilience, (3) ecosystem monetization.
 Verdict: Watch with quality bias.
 What could break thesis: ecosystem lock-in weaker than expected.</td><td><span class="star">☆☆☆☆☆</span> (0)</td></tr>
-      <tr><td>EWY</td><td>iShares MSCI South Korea ETF</td><td>2026-02-22</td><td></td><td class="notes-cell">Thesis: Korea equity beta (heavy semis/export cyclicals).
+<tr><td>EWY</td><td>iShares MSCI South Korea ETF</td><td>2026-02-22</td><td></td><td class="notes-cell">Thesis: Korea equity beta (heavy semis/export cyclicals).
 Market pricing in: memory cycle recovery + KRW/macroeconomic stability.
 Catalysts: DRAM/NAND upcycle, China demand, global electronics recovery.
 Moat/Risks: diversified country exposure; risk = geopolitical/regulatory shocks.
@@ -271,7 +272,7 @@ Red flags: earnings downgrades in Samsung/SK hynix, FX stress.
 Checkpoints: (1) semiconductor cycle data, (2) export momentum, (3) policy/geopolitical risk.
 Verdict: Macro/cycle tool, not single-company thesis.
 What could break thesis: memory downturn returns quickly.</td><td><span class="star">★★☆☆☆</span> (2)</td></tr>
-      <tr><td>AXTI</td><td>AXT Inc</td><td>2026-02-22</td><td>photonics</td><td class="notes-cell">Thesis: Compound semiconductor substrate supplier leveraged to RF/optical/power trends.
+<tr><td>AXTI</td><td>AXT Inc</td><td>2026-02-22</td><td>photonics</td><td class="notes-cell">Thesis: Compound semiconductor substrate supplier leveraged to RF/optical/power trends.
 Market pricing in: cyclical rebound and share gains in key substrate categories.
 Catalysts: end-market recovery (smartphone/telecom/datacenter), new design wins.
 Moat/Risks: materials know-how; risk = pricing pressure, customer concentration, geopolitics.
@@ -281,7 +282,7 @@ Red flags: persistent negative operating leverage, weak bookings.
 Checkpoints: (1) utilization recovery, (2) margin expansion, (3) diversified customer mix.
 Verdict: Cyclical Watch.
 What could break thesis: demand recovery delayed again.</td><td><span class="star">★☆☆☆☆</span> (1)</td></tr>
-      <tr><td>SMTOY</td><td>Sumitomo Electric Industries Lt</td><td>2026-02-22</td><td></td><td class="notes-cell">Thesis: Diversified industrial/electrical components with auto harness leadership.
+<tr><td>SMTOY</td><td>Sumitomo Electric Industries Lt</td><td>2026-02-22</td><td></td><td class="notes-cell">Thesis: Diversified industrial/electrical components with auto harness leadership.
 Market pricing in: stable industrial demand + EV/content tailwinds.
 Catalysts: auto electrification mix, power cable/infrastructure demand.
 Moat/Risks: scale + customer relationships; risk = auto cycle, commodity inputs.
@@ -291,7 +292,7 @@ Red flags: auto weakness, margin squeeze from input costs.
 Checkpoints: (1) margin by segment, (2) auto order trends, (3) capex efficiency.
 Verdict: Quality cyclical, monitor cycle timing.
 What could break thesis: prolonged auto downturn.</td><td><span class="star">☆☆☆☆☆</span> (0)</td></tr>
-      <tr><td>XLU</td><td>State Street Utilities Select S</td><td>2026-02-22</td><td></td><td class="notes-cell">Thesis: U.S. utilities defensive yield exposure.
+<tr><td>XLU</td><td>State Street Utilities Select S</td><td>2026-02-22</td><td></td><td class="notes-cell">Thesis: U.S. utilities defensive yield exposure.
 Market pricing in: rate path + regulated return outlook.
 Catalysts: rate cuts/declines in long yields, grid investment cycle.
 Moat/Risks: regulated cash flows; risk = higher-for-longer rates, regulatory lag.
@@ -301,7 +302,7 @@ Red flags: adverse regulatory rulings, weak balance sheets in top holdings.
 Checkpoints: (1) Treasury yield trend, (2) rate-case outcomes, (3) dividend coverage.
 Verdict: Defensive allocation tool.
 What could break thesis: real rates stay elevated.</td><td><span class="star">★★☆☆☆</span> (2)</td></tr>
-      <tr><td>AMPX</td><td>Amprius Technologies, Inc.</td><td>2026-02-23</td><td></td><td class="notes-cell">Thesis: High-energy-density battery tech optionality (aviation/defense).
+<tr><td>AMPX</td><td>Amprius Technologies, Inc.</td><td>2026-02-23</td><td></td><td class="notes-cell">Thesis: High-energy-density battery tech optionality (aviation/defense).
 Market pricing in: transition from pilot validation to scalable production.
 Catalysts: qualification milestones, commercial contracts, manufacturing scale proof.
 Moat/Risks: chemistry/performance edge; risk = scale-up and cash burn.
@@ -311,7 +312,7 @@ Red flags: repeated production delays, rising dilution.
 Checkpoints: (1) customer qualification completions, (2) yield improvements, (3) funding adequacy.
 Verdict: Speculative.
 What could break thesis: scale economics never converge.</td><td><span class="star">★★☆☆☆</span> (2)</td></tr>
-      <tr><td>5210.T</td><td>NIHON YAMAMURA GLASS CO</td><td>2026-02-24</td><td></td><td class="notes-cell">Thesis: Niche glass/packaging/industrial exposure with cyclical demand sensitivity.
+<tr><td>5210.T</td><td>NIHON YAMAMURA GLASS CO</td><td>2026-02-24</td><td></td><td class="notes-cell">Thesis: Niche glass/packaging/industrial exposure with cyclical demand sensitivity.
 Market pricing in: domestic industrial recovery and stable input costs.
 Catalysts: utilization rebound, pricing pass-through, product mix improvement.
 Moat/Risks: manufacturing footprint; risk = energy/input volatility and demand softness.
@@ -321,7 +322,7 @@ Red flags: weak capacity utilization, margin erosion.
 Checkpoints: (1) price-cost spread, (2) utilization trend, (3) leverage.
 Verdict: Small-cap cyclical watch.
 What could break thesis: sustained weak end-demand.</td><td><span class="star">☆☆☆☆☆</span> (0)</td></tr>
-      <tr><td>IQE.L</td><td>IQE PLC ORD 1P</td><td>2026-02-25</td><td></td><td class="notes-cell">Thesis: Epitaxy/materials supplier tied to photonics and semiconductor demand recovery.
+<tr><td>IQE.L</td><td>IQE PLC ORD 1P</td><td>2026-02-25</td><td></td><td class="notes-cell">Thesis: Epitaxy/materials supplier tied to photonics and semiconductor demand recovery.
 Market pricing in: cyclical rebound + strategic relevance in advanced chips/photonics.
 Catalysts: order recovery, customer qualification wins, margin normalization.
 Moat/Risks: process expertise; risk = customer concentration + prolonged downturn.
@@ -331,8 +332,8 @@ Red flags: recurring capital raises without operating inflection.
 Checkpoints: (1) bookings trend, (2) margin inflection, (3) balance-sheet resilience.
 Verdict: Turnaround watchlist only.
 What could break thesis: recovery keeps slipping.</td><td><span class="star">★★★☆☆</span> (3)</td></tr>
-      <tr><td>LITE</td><td>Lumentum Holdings Inc.</td><td>2026-02-25</td><td>photonics</td><td class="notes-cell">&lt;a href="https://x.com/aleabitoreddit/status/2026626382504272279?s=46"&gt;https://x.com/aleabitoreddit/status/2026626382504272279?s=46&lt;/a&gt;</td><td><span class="star">★★★☆☆</span> (3)</td></tr>
-      <tr><td>005930.KS</td><td>SamsungElec</td><td>2026-02-25</td><td></td><td class="notes-cell">Thesis: Scale leader across memory, foundry, mobile and consumer electronics.
+<tr><td>LITE</td><td>Lumentum Holdings Inc.</td><td>2026-02-25</td><td>photonics</td><td class="notes-cell">&lt;a href="https://x.com/aleabitoreddit/status/2026626382504272279?s=46"&gt;https://x.com/aleabitoreddit/status/2026626382504272279?s=46&lt;/a&gt;</td><td><span class="star">★★★☆☆</span> (3)</td></tr>
+<tr><td>005930.KS</td><td>SamsungElec</td><td>2026-02-25</td><td></td><td class="notes-cell">Thesis: Scale leader across memory, foundry, mobile and consumer electronics.
 Market pricing in: memory upcycle + AI-related demand support.
 Catalysts: DRAM/NAND pricing, HBM competitiveness, foundry execution.
 Moat/Risks: scale/capex/vertical integration; risk = memory volatility + foundry share pressure.
@@ -342,7 +343,7 @@ Red flags: HBM execution gap, prolonged foundry underperformance.
 Checkpoints: (1) memory ASP trend, (2) HBM share progress, (3) margin recovery quality.
 Verdict: Core cyclical quality.
 What could break thesis: weaker-than-expected AI memory monetization.</td><td><span class="star">☆☆☆☆☆</span> (0)</td></tr>
-      <tr><td>000660.KS</td><td>SK hynix</td><td>2026-02-26</td><td></td><td class="notes-cell">Thesis: Memory pure-play with high AI leverage via HBM leadership.
+<tr><td>000660.KS</td><td>SK hynix</td><td>2026-02-26</td><td></td><td class="notes-cell">Thesis: Memory pure-play with high AI leverage via HBM leadership.
 Market pricing in: sustained HBM demand + favorable memory cycle.
 Catalysts: HBM capacity expansion, AI server demand, pricing discipline.
 Moat/Risks: execution in advanced memory; risk = capex overshoot + cycle reversal.
@@ -352,7 +353,7 @@ Red flags: inventory rebuild + ASP pressure, customer concentration risk.
 Checkpoints: (1) HBM shipment growth, (2) gross margin durability, (3) capex/FCF balance.
 Verdict: High-beta AI memory exposure.
 What could break thesis: sharp memory downcycle returns.</td><td><span class="star">☆☆☆☆☆</span> (0)</td></tr>
-      <tr><td>AEHR</td><td>Aehr Test Systems</td><td>2026-02-26</td><td></td><td class="notes-cell">Thesis: Test/burn-in equipment levered to SiC and power semiconductor adoption.
+<tr><td>AEHR</td><td>Aehr Test Systems</td><td>2026-02-26</td><td></td><td class="notes-cell">Thesis: Test/burn-in equipment levered to SiC and power semiconductor adoption.
 Market pricing in: strong multi-year SiC demand and customer capex continuity.
 Catalysts: EV power semiconductor volumes, new customer ramps.
 Moat/Risks: niche test positioning; risk = capex lumpiness + customer concentration.
@@ -362,25 +363,168 @@ Red flags: order push-outs, dependency on few end-customers.
 Checkpoints: (1) diversified customer base, (2) recurring service mix, (3) backlog conversion.
 Verdict: Attractive niche but cyclic/lumpy.
 What could break thesis: SiC capex pause.</td><td><span class="star">☆☆☆☆☆</span> (0)</td></tr>
-      <tr><td>6101.T</td><td>TSUGAMI CORP</td><td>2026-02-27</td><td></td><td class="notes-cell">Machines for robotic components</td><td><span class="star">★★★★★</span> (5)</td></tr>
-      <tr><td>SIVE.ST</td><td>Sivers Semiconductors AB</td><td>2026-03-17</td><td>photonics</td><td class="notes-cell"></td><td><span class="star">★★★☆☆</span> (3)</td></tr>
-      <tr><td>POET</td><td>POET Technologies Inc.</td><td>2026-03-17</td><td>photonics</td><td class="notes-cell"></td><td><span class="star">★☆☆☆☆</span> (1)</td></tr>
-      <tr><td>MRVL</td><td>Marvell Technology, Inc.</td><td>2026-03-17</td><td>photonics</td><td class="notes-cell"></td><td><span class="star">★☆☆☆☆</span> (1)</td></tr>
-      <tr><td>SOI.PA</td><td>SOITEC</td><td>2026-03-01</td><td>photonics</td><td class="notes-cell"></td><td><span class="star">☆☆☆☆☆</span> (0)</td></tr>
-      <tr><td>TSEM</td><td>Tower Semiconductor Ltd.</td><td>2026-03-17</td><td>photonics</td><td class="notes-cell"></td><td><span class="star">☆☆☆☆☆</span> (0)</td></tr>
-      <tr><td>COHR</td><td>Coherent Corp.</td><td>2026-03-17</td><td>photonics</td><td class="notes-cell"></td><td><span class="star">☆☆☆☆☆</span> (0)</td></tr>
-      <tr><td>AAOI</td><td>Applied Optoelectronics, Inc.</td><td>2026-03-01</td><td>photonics</td><td class="notes-cell"></td><td><span class="star">☆☆☆☆☆</span> (0)</td></tr>
-      <tr><td>DNA</td><td>Ginkgo Bioworks Holdings, Inc.</td><td>2026-03-17</td><td>genetics</td><td class="notes-cell"></td><td><span class="star">★☆☆☆☆</span> (1)</td></tr>
-      <tr><td>SMTC</td><td>Semtech Corporation</td><td>2026-03-17</td><td>photonics</td><td class="notes-cell"></td><td><span class="star">☆☆☆☆☆</span> (0)</td></tr>
-      <tr><td>PL</td><td>Planet Labs PBC</td><td>2026-03-01</td><td>space</td><td class="notes-cell"></td><td><span class="star">★★☆☆☆</span> (2)</td></tr>
-      <tr><td>TPE.F</td><td>PVA TePla AG                  I</td><td>2026-03-20</td><td>photonics</td><td class="notes-cell"></td><td><span class="star">☆☆☆☆☆</span> (0)</td></tr>
-      <tr><td>BMBL</td><td>Bumble Inc.</td><td>2026-03-21</td><td>value</td><td class="notes-cell">
-</td><td><span class="star">★★☆☆☆</span> (2)</td></tr>
-      <tr><td>NOC</td><td>Northrop Grumman Corporation</td><td>2026-03-22</td><td>space</td><td class="notes-cell"></td><td><span class="star">☆☆☆☆☆</span> (0)</td></tr>
-      <tr><td>LHX</td><td>L3Harris Technologies, Inc.</td><td>2026-03-22</td><td>space</td><td class="notes-cell"></td><td><span class="star">☆☆☆☆☆</span> (0)</td></tr>
-      <tr><td>LASR</td><td>nLIGHT, Inc.</td><td>2026-03-22</td><td>space</td><td class="notes-cell"></td><td><span class="star">☆☆☆☆☆</span> (0)</td></tr>
-      <tr><td>IPGP</td><td>IPG Photonics Corporation</td><td>2026-03-22</td><td>space</td><td class="notes-cell"></td><td><span class="star">☆☆☆☆☆</span> (0)</td></tr>
-      <tr><td>ASTS</td><td>AST SpaceMobile, Inc.</td><td>2026-03-22</td><td>space</td><td class="notes-cell"></td><td><span class="star">☆☆☆☆☆</span> (0)</td></tr>
-      <tr><td>LUNR</td><td>Intuitive Machines, Inc.</td><td>2026-03-22</td><td>space</td><td class="notes-cell"></td><td><span class="star">☆☆☆☆☆</span> (0)</td></tr>
+<tr><td>6101.T</td><td>TSUGAMI CORP</td><td>2026-02-27</td><td></td><td class="notes-cell">Machines for robotic components</td><td><span class="star">★★★★★</span> (5)</td></tr>
+<tr><td>SIVE.ST</td><td>Sivers Semiconductors AB</td><td>2026-03-17</td><td>photonics</td><td class="notes-cell">Thesis (contrarian): Everyone wants AI glamour chips; this one sells shovels and adapters while the crowd is buying glitter cannons.
+Market pricing in: FACT: likely pricing either optical networking upside or another false dawn. INFERENCE: market confidence is fragile and headline-dependent.
+Catalysts (90d): product design-wins chatter, inventory normalization, and any real margin stabilization.
+Moat + risks: Moat is niche know-how; risk is becoming "technically great, commercially invisible." Also customer concentration can turn quarter-to-quarter into a mood swing.
+Financial quality snapshot: treat as turnaround math, not compounding-machine math.
+Valuation sanity: if you need heroic assumptions and a drum solo to justify the multiple, it is not cheap.
+Red flags: recurring dilution, guidance whiplash, backlog quality not just backlog size.
+What must happen next: (1) sustained gross-margin improvement, (2) cleaner cash conversion, (3) at least one sticky high-value customer ramp.
+Verdict: Watch (contrarian nibble only), confidence 61/100. Thesis-breaker: another year of "next quarter" optimism with no operating leverage.</td><td><span class="star">★★★☆☆</span> (3)</td></tr>
+<tr><td>POET</td><td>POET Technologies Inc.</td><td>2026-03-17</td><td>photonics</td><td class="notes-cell">Thesis (contrarian): The story is "faster optics"; the hidden question is "who pays enough for it at scale?"
+Market pricing in: strong platform optionality and eventual hyperscaler adoption.
+Catalysts (90d): customer validation milestones, manufacturing readiness signals, and credible volume timeline.
+Moat + risks: elegant integration narrative; brutal execution gauntlet. Physics does not care about investor decks.
+Financial quality snapshot: pre-scale profile; focus on burn discipline and funding runway, not vanity revenue.
+Valuation sanity: this is venture-style equity wearing public-market clothes.
+Red flags: perpetual pilot programs, blurry unit economics, dependence on external financing windows.
+What must happen next: (1) convert pilots to contracted volume, (2) prove repeatable yield, (3) reduce cash-burn slope.
+Verdict: Watch/Avoid boundary; confidence 57/100. Metaphor: cool rocket, still on launchpad blocks.</td><td><span class="star">★☆☆☆☆</span> (1)</td></tr>
+<tr><td>MRVL</td><td>Marvell Technology, Inc.</td><td>2026-03-17</td><td>photonics</td><td class="notes-cell">Thesis (contrarian): Quality company, but consensus already wrote the happy ending in pen.
+Market pricing in: AI networking growth with limited stumbles.
+Catalysts (90d): cloud capex trends, design-win monetization, and margin trajectory against expectations.
+Moat + risks: strong customer relationships + execution culture; risk is cyclicality disguised as secular destiny.
+Financial quality snapshot: better than most peers, but still subject to inventory and demand digestion cycles.
+Valuation sanity: not absurd, not forgiving.
+Red flags: overdependence on a few mega-customers and extrapolating peak demand forever.
+What must happen next: (1) sustained data-center growth quality, (2) stable gross margin under mix shifts, (3) no inventory relapse.
+Verdict: Buy on fear, not on euphoria. Confidence 68/100.</td><td><span class="star">★☆☆☆☆</span> (1)</td></tr>
+<tr><td>SOI.PA</td><td>SOITEC</td><td>2026-03-01</td><td>photonics</td><td class="notes-cell">Thesis (contrarian): This is a "boring enabler" business in a market addicted to fireworks. Boring can compound.
+Market pricing in: cyclical pressure now, eventual substrate demand rebound later.
+Catalysts (90d): fab utilization trends, automotive/industrial demand, and margin floor evidence.
+Moat + risks: technical barriers in advanced materials; risk is long customer qualification cycles plus cyclical under-absorption.
+Financial quality snapshot: watch balance-sheet stamina and capex discipline through the cycle trough.
+Valuation sanity: can look expensive at the bottom and cheap at the top — invert your instincts.
+Red flags: capex sprint without demand visibility, slow inventory normalization.
+What must happen next: (1) utilization improvement, (2) pricing resilience, (3) free-cash-flow inflection.
+Verdict: Watch with a patient clock. Confidence 64/100. Metaphor: like owning the road, not the race car.</td><td><span class="star">☆☆☆☆☆</span> (0)</td></tr>
+<tr><td>TSEM</td><td>Tower Semiconductor Ltd.</td><td>2026-03-17</td><td>photonics</td><td class="notes-cell">Thesis (contrarian): Specialty foundry is less sexy than frontier-node drama, but often more rational.
+Market pricing in: steady analog/power demand with moderate cyclic recovery.
+Catalysts (90d): capacity utilization trend, customer mix quality, and margin consistency.
+Moat + risks: process specialization and sticky customer relationships; risk is being squeezed between giant foundries and niche competitors.
+Financial quality snapshot: look for cash generation consistency rather than headline growth theatrics.
+Valuation sanity: fair if execution remains boringly good.
+Red flags: margin compression with no mix recovery, capex creep, customer concentration shocks.
+What must happen next: (1) maintain utilization, (2) protect gross margin, (3) show durable free cash flow.
+Verdict: Buy/Watch depending on entry price. Confidence 66/100.</td><td><span class="star">☆☆☆☆☆</span> (0)</td></tr>
+<tr><td>COHR</td><td>Coherent Corp.</td><td>2026-03-17</td><td>photonics</td><td class="notes-cell">Thesis (contrarian): Great technology plus messy integration equals opportunity *and* trap.
+Market pricing in: synergy delivery and optical cycle tailwinds.
+Catalysts (90d): post-merger execution KPIs, debt reduction cadence, and order quality.
+Moat + risks: deep photonics expertise; risk is integration indigestion and balance-sheet drag.
+Financial quality snapshot: debt + restructuring reality check required before story premium.
+Valuation sanity: cheap-looking multiples can be a mirror maze when earnings quality is unsettled.
+Red flags: synergy promises outrunning reported progress, working-capital strain.
+What must happen next: (1) prove merger synergies in margins, (2) de-lever credibly, (3) stabilize demand visibility.
+Verdict: Contrarian Watch with sharp risk controls. Confidence 60/100.</td><td><span class="star">☆☆☆☆☆</span> (0)</td></tr>
+<tr><td>AAOI</td><td>Applied Optoelectronics, Inc.</td><td>2026-03-01</td><td>photonics</td><td class="notes-cell">Thesis (contrarian): Possibly a cyclical rebound vehicle masquerading as a secular winner.
+Market pricing in: AI/networking demand wave lifting all optical boats.
+Catalysts (90d): shipment momentum, margin recovery, customer concentration updates.
+Moat + risks: vertical integration can help; risk is price pressure and lumpy demand from a handful of buyers.
+Financial quality snapshot: historically volatile — treat cash and margins as the truth serum.
+Valuation sanity: high beta, high narrative elasticity.
+Red flags: sequential volatility, thin visibility, sudden pricing resets.
+What must happen next: (1) sustain gross-margin expansion, (2) broaden customer base, (3) reduce quarter-to-quarter whiplash.
+Verdict: Watch (speculative). Confidence 55/100. Metaphor: rollercoaster with great views and no seatbelt.</td><td><span class="star">☆☆☆☆☆</span> (0)</td></tr>
+<tr><td>DNA</td><td>Ginkgo Bioworks Holdings, Inc.</td><td>2026-03-17</td><td>genetics</td><td class="notes-cell">Thesis (contrarian): Visionary platform story, but market has become allergic to long-duration promises.
+Market pricing in: eventual foundry/platform monetization with improving discipline.
+Catalysts (90d): partnership quality, program conversion to recurring revenue, burn-rate trajectory.
+Moat + risks: strong technical ambition; risk is commercialization drag and dilution gravity.
+Financial quality snapshot: prioritize runway, unit economics, and operating discipline.
+Valuation sanity: option-like; position size should reflect that reality.
+Red flags: growth without gross-profit quality, perpetual restructuring language.
+What must happen next: (1) prove repeatable high-quality revenue, (2) reduce cash burn materially, (3) show credible path to self-funding.
+Verdict: Avoid for now unless you like science fiction with financing risk. Confidence 63/100.</td><td><span class="star">★☆☆☆☆</span> (1)</td></tr>
+<tr><td>SMTC</td><td>Semtech Corporation</td><td>2026-03-17</td><td>photonics</td><td class="notes-cell">Thesis (contrarian): Could be a quiet beneficiary if connectivity complexity rises, but debt and cycle scars matter.
+Market pricing in: recovery and cleaner execution post-reset.
+Catalysts (90d): margin trajectory, demand stabilization, and debt-service comfort.
+Moat + risks: useful portfolio in messy real-world connectivity; risk is leverage + competitive pricing pressure.
+Financial quality snapshot: balance-sheet strength is the main character, not the revenue headline.
+Valuation sanity: can rerate fast if execution improves, rerate down faster if not.
+Red flags: weak free cash flow, soft guidance, customer destocking persistence.
+What must happen next: (1) consistent positive FCF, (2) deleveraging progress, (3) evidence of demand normalization.
+Verdict: Watch with a calculator, not with vibes. Confidence 62/100.</td><td><span class="star">☆☆☆☆☆</span> (0)</td></tr>
+<tr><td>PL</td><td>Planet Labs PBC</td><td>2026-03-01</td><td>space</td><td class="notes-cell">Thesis (contrarian): Earth-observation sounds noble; the hard part is turning images into sticky software-like revenue.
+Market pricing in: platform expansion and defense/commercial demand durability.
+Catalysts (90d): contract wins quality, subscription mix, and gross-margin direction.
+Moat + risks: data asset + constellation scale; risk is commoditization and contract lumpiness.
+Financial quality snapshot: revenue growth alone is insufficient — look at cash burn and retention quality.
+Valuation sanity: narrative premium exists, must be earned with execution.
+Red flags: one-off contract dependence, slow path to operating leverage.
+What must happen next: (1) improve recurring mix, (2) tighten burn, (3) demonstrate durable customer retention.
+Verdict: Watch (interesting, not proven). Confidence 58/100. Metaphor: amazing telescope, still building the business model tripod.</td><td><span class="star">★★☆☆☆</span> (2)</td></tr>
+<tr><td>TPE.F</td><td>PVA TePla AG                  I</td><td>2026-03-20</td><td>photonics</td><td class="notes-cell">Thesis (contrarian): Industrial metrology is where hype goes to get audited by reality.
+Market pricing in: semiconductor capex recovery feeding equipment demand.
+Catalysts (90d): order intake trend, backlog quality, and margin resilience.
+Moat + risks: precision equipment know-how; risk is capex cycle air pockets and customer timing.
+Financial quality snapshot: look for disciplined working capital and conversion from orders to cash.
+Valuation sanity: cyclical name — buy gloom, trim sunshine.
+Red flags: order volatility, backlog cancellations, margin slippage.
+What must happen next: (1) order momentum confirmation, (2) margin stability, (3) clean cash conversion.
+Verdict: Buy/Watch tactical. Confidence 65/100.</td><td><span class="star">☆☆☆☆☆</span> (0)</td></tr>
+<tr><td>BMBL</td><td>Bumble Inc.</td><td>2026-03-21</td><td>value</td><td class="notes-cell">Thesis (contrarian): Dating apps are like nightclubs: fun concept, brutal retention economics, constant reinvention tax.
+Market pricing in: either secular decline fears or a turnaround nobody believes yet.
+Catalysts (90d): product engagement metrics, payer trends, and marketing efficiency.
+Moat + risks: brand recognition exists; moat is weaker than users think because switching cost is basically thumb movement.
+Financial quality snapshot: watch user monetization quality vs customer-acquisition spend.
+Valuation sanity: cheap can stay cheap if engagement decays.
+Red flags: falling payer growth, rising promo intensity, weak cohort retention.
+What must happen next: (1) stabilize engagement, (2) improve payer monetization without ad-spend bloat, (3) show durable product differentiation.
+Verdict: Avoid until the turnaround has receipts. Confidence 70/100.</td><td><span class="star">★★☆☆☆</span> (2)</td></tr>
+<tr><td>NOC</td><td>Northrop Grumman Corporation</td><td>2026-03-22</td><td>space</td><td class="notes-cell">Thesis (contrarian): Defense primes look boring until geopolitics sends everyone back to cash-flow reality.
+Market pricing in: durable defense spend with execution stability.
+Catalysts (90d): contract awards, margin mix, and program execution milestones.
+Moat + risks: moat is scale + certifications; risk is cost overruns and political budget theatrics.
+Financial quality snapshot: generally sturdy; still monitor working-capital swings on big programs.
+Valuation sanity: quality premium often justified, but not at any price.
+Red flags: fixed-price contract pain, schedule slips, pension surprises.
+What must happen next: (1) clean execution on key programs, (2) margin resilience, (3) backlog conversion quality.
+Verdict: Buy on dips. Confidence 71/100.</td><td><span class="star">☆☆☆☆☆</span> (0)</td></tr>
+<tr><td>LHX</td><td>L3Harris Technologies, Inc.</td><td>2026-03-22</td><td>space</td><td class="notes-cell">Thesis (contrarian): Mission-critical electronics is less memeable than AI chips, but often stickier.
+Market pricing in: steady defense demand and integration execution.
+Catalysts (90d): order momentum, margin performance, and deleveraging cadence.
+Moat + risks: sticky systems integration; risk is procurement delays and integration complexity.
+Financial quality snapshot: check conversion from adjusted earnings to cash.
+Valuation sanity: fair if execution remains predictable.
+Red flags: guidance compression, backlog quality deterioration, cash conversion miss.
+What must happen next: (1) maintain margin discipline, (2) preserve cash generation, (3) secure high-value program wins.
+Verdict: Watch/Buy depending on entry. Confidence 67/100.</td><td><span class="star">☆☆☆☆☆</span> (0)</td></tr>
+<tr><td>LASR</td><td>nLIGHT, Inc.</td><td>2026-03-22</td><td>space</td><td class="notes-cell">Thesis (contrarian): Lidar is where physics, pricing pressure, and investor patience fight in a small room.
+Market pricing in: eventual autonomous/industrial adoption upside.
+Catalysts (90d): contract wins that actually ship, gross-margin trend, and burn-rate control.
+Moat + risks: tech differentiation potential; risk is commoditization before scale economics arrive.
+Financial quality snapshot: runway is king.
+Valuation sanity: binary-ish and narrative-heavy.
+Red flags: pilot purgatory, customer concentration, repeated timeline slips.
+What must happen next: (1) convert pilots to production, (2) improve unit economics, (3) reduce burn without stalling growth.
+Verdict: Watch (speculative). Confidence 54/100.</td><td><span class="star">☆☆☆☆☆</span> (0)</td></tr>
+<tr><td>IPGP</td><td>IPG Photonics Corporation</td><td>2026-03-22</td><td>space</td><td class="notes-cell">Thesis (contrarian): Industrial laser incumbent with less hype, more installed-base reality.
+Market pricing in: cyclical softness and gradual recovery.
+Catalysts (90d): order recovery signs, margin stabilization, and end-market demand breadth.
+Moat + risks: strong engineering + installed base; risk is cyclical demand and pricing competition.
+Financial quality snapshot: usually solid balance-sheet profile matters in downturns.
+Valuation sanity: potentially attractive when cycle pessimism is high.
+Red flags: prolonged end-market weakness, margin erosion, inventory issues.
+What must happen next: (1) order trend turn, (2) margin floor hold, (3) cash-flow consistency.
+Verdict: Contrarian Buy/Watch. Confidence 66/100.</td><td><span class="star">☆☆☆☆☆</span> (0)</td></tr>
+<tr><td>ASTS</td><td>AST SpaceMobile, Inc.</td><td>2026-03-22</td><td>space</td><td class="notes-cell">Thesis (contrarian): The dream is gigantic; the execution path is a minefield of physics, capital, and regulation.
+Market pricing in: successful direct-to-device scaling.
+Catalysts (90d): satellite deployment milestones, partner updates, and financing clarity.
+Moat + risks: if it works, moat could be huge; if delays stack, dilution risk gets loud.
+Financial quality snapshot: pre-cashflow venture profile.
+Valuation sanity: option-like with dramatic upside and equally dramatic fragility.
+Red flags: launch delays, funding gaps, technical underperformance.
+What must happen next: (1) hit deployment milestones, (2) secure non-dilutive capital where possible, (3) demonstrate service reliability.
+Verdict: Watch/speculative only. Confidence 56/100. Metaphor: beautiful cathedral blueprint, still pouring concrete.</td><td><span class="star">☆☆☆☆☆</span> (0)</td></tr>
+<tr><td>LUNR</td><td>Intuitive Machines, Inc.</td><td>2026-03-22</td><td>space</td><td class="notes-cell">Thesis (contrarian): Space enthusiasm is easy; repeatable mission economics are hard.
+Market pricing in: program wins and execution credibility in a crowded space narrative.
+Catalysts (90d): mission outcomes, contract pipeline quality, and cash runway updates.
+Moat + risks: differentiated mission profile possible; risk is one mission hiccup rewriting the entire story.
+Financial quality snapshot: lumpy revenue profile; prioritize liquidity and contract quality.
+Valuation sanity: volatility is a feature, not a bug.
+Red flags: milestone slips, concentration risk, financing dependence.
+What must happen next: (1) flawless mission execution, (2) backlog with real margin quality, (3) improved cash visibility.
+Verdict: Watch (high-risk, high-drama). Confidence 59/100.</td><td><span class="star">☆☆☆☆☆</span> (0)</td></tr>
 </tbody></table>
 <p><small>Generated by Stock Tracker - 64 stocks</small></p></body></html>


### PR DESCRIPTION
## Summary
Filled every stock with previously empty notes in `portfolio.html` using the in-app LLM instruction style (thesis, pricing-in view, catalysts, moat/risks, valuation sanity, red flags, checkpoints, verdict), with a more unconventional/contrarian/funny metaphorical tone.

## What changed
- Updated **all previously empty** notes cells in portfolio entries.
- Notes now follow a compact structured format inspired by `DEFAULT_LLM_GUIDE`.
- Tone intentionally includes contrarian framing and metaphors per request.

## Result
- Empty notes before: 18
- Empty notes after: 0

No code behavior changes, only portfolio content enrichment.
