### PR TITLE
fix: make market-data CORS warning toast opt-in

### DIFF
--- a/src/yahoo.js
+++ b/src/yahoo.js
@@ -23,6 +23,30 @@ function sleep(ms) {
     return new Promise(resolve => setTimeout(resolve, ms));
 }
 
+let corsWarningShown = false;
+const SHOW_CORS_TOAST = localStorage.getItem('show_cors_warning_toast') === '1';
+
+function isLikelyCorsOrNetworkError(err) {
+    const msg = String(err?.message || '').toLowerCase();
+    return msg.includes('failed to fetch') || msg.includes('networkerror') || msg.includes('load failed') || msg.includes('typeerror');
+}
+
+function showCorsWarningOnce() {
+    if (corsWarningShown) return;
+    corsWarningShown = true;
+
+    // Keep this silent by default to avoid noisy warning toasts.
+    // Opt-in for debugging with: localStorage.setItem('show_cors_warning_toast', '1')
+    if (!SHOW_CORS_TOAST) {
+        mdWarn('Market data request blocked (likely CORS/network). Enable CORS for query1.finance.yahoo.com and refresh.');
+        return;
+    }
+
+    if (typeof window.showStatus === 'function') {
+        window.showStatus('Market data blocked (likely CORS/network). Enable CORS for query1.finance.yahoo.com and refresh.', 'error');
+    }
+}
+
 async function fetchJsonDirect(url, label = 'request') {
     for (let attempt = 0; attempt < 3; attempt++) {
         try {
@@ -37,6 +61,7 @@ async function fetchJsonDirect(url, label = 'request') {
                 await sleep(delayMs);
                 continue;
             }
+            if (isLikelyCorsOrNetworkError(err)) showCorsWarningOnce();
             throw err;
         }
     }


### PR DESCRIPTION
## Summary
Reduces noisy warning toasts from market-data fetch failures by making the CORS warning toast opt-in.

## Changes
- Added CORS/network error detection helper.
- Show warning only once per session.
- Default behavior: debug log only (no toast spam).
- Optional toast behavior can be re-enabled via:
  - `localStorage.setItem('show_cors_warning_toast', '1')`

## Why
Addresses issue #44 item about CORS warning noise while still keeping a clear debug path for troubleshooting.

Fixes #44
