### PR TITLE
fix: add issue link button and live notes preview refresh

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -135,6 +135,7 @@
         <div id="portfolio-actions" class="actions-section">
             <button id="save-portfolio" class="btn-primary" disabled>💾 Save to GitHub</button>
             <button id="llm-guide-btn" class="btn-secondary">🤖 LLM Instructions</button>
+            <a id="issue-link-btn" href="https://github.com/jeromevde/Stocks/issues/44" target="_blank" rel="noopener noreferrer" class="btn-secondary">🐞 Issue #44</a>
             <a href="https://github.com/jeromevde/Stocks" target="_blank" rel="noopener noreferrer" class="repo-title-link">Stock Tracker ↗</a>
         </div>
         <div id="label-tabs" class="label-tabs" style="display:none;"></div>

--- a/src/ui.js
+++ b/src/ui.js
@@ -282,7 +282,7 @@ function updatePortfolioTable() {
 function buildResearchPrompt(stock) {
     const name = stock?.name || stock?.ticker || '';
     const ticker = stock?.ticker || '';
-    return `What does ${name} (${ticker}) sell?\n\nGive a concise breakdown of main revenue sources by segment and geography (latest fiscal year), with percentages when available.\n\nAlso include:\n- Business model summary\n- Top 3 growth drivers\n- Top 3 key risks\n- Competitors\n- What to verify in latest annual report/10-K`;
+    return `What does ${name} (${ticker}) sell?\n\nKeep it SHORT (max 120 words excluding table), practical, and decision-focused.\n\nUse exactly one compact markdown table:\n\n| Item | Notes |\n|---|---|\n| Business model | one-liner |\n| Revenue mix | key segments/geographies with % when known |\n| Growth drivers | top 2 |\n| Risks | top 2 |\n\nThen add 3 bullets only:\n- What market is pricing in\n- What to verify in latest filing\n- Verdict: Bull / Neutral / Bear + confidence (0-100)`;
 }
 
 function openProviderChat(provider, stock) {
@@ -477,6 +477,14 @@ function openNotesPopup(idx) {
     renderNotesHeader(idx);
     const editor = document.getElementById('notes-editor');
     editor.innerHTML = parseMedia(stock.notes || '');
+
+    // Live-sync notes so table previews update without manual page refresh.
+    editor.oninput = () => {
+        if (currentNotesStockIndex === null) return;
+        window.Portfolio.updateNotes(currentNotesStockIndex, serializeNotes(editor));
+        if (typeof window.debouncedUpdateTable === 'function') window.debouncedUpdateTable();
+    };
+
     overlay.style.display = 'flex';
     setTimeout(() => { overlay.classList.add('show'); editor.focus(); }, 10);
 }


### PR DESCRIPTION
## Summary
Addresses three unchecked issue items in #44:
- add a button that links to the GitHub issue
- new notes don't appear in table view without refresh
- LLM-generated output should be shorter / table-friendly

## Changes
1. Added a new action button in the header:
   - `🐞 Issue #44` linking to `https://github.com/jeromevde/Stocks/issues/44`
2. Implemented live note syncing while typing in the notes popup:
   - on `notes-editor` input, notes are persisted and table preview is debounced/refreshed
   - removes need for manual page reload to see updates
3. Tightened the quick research prompt format:
   - max 120 words (excluding table)
   - exactly one compact markdown table
   - only 3 follow-up bullets

## Validation
- `node --check src/ui.js`

Fixes #44
