### PR TITLE
fix: support markdown tables + richer media rendering in notes

### DIFF
--- a/src/ui.js
+++ b/src/ui.js
@@ -91,6 +91,9 @@ function getNotesPreview(notes) {
 
     let text = String(notes);
 
+    // Collapse markdown tables to a compact marker in row preview.
+    text = text.replace(/(^|\n)\|.+\|\n\|[-:| ]+\|(?:\n\|.*\|)*/gmi, '\n[table]\n');
+
     // Replace embedded HTML media first
     text = text.replace(/<img\b[^>]*>/gi, '[image]');
     text = text.replace(/<video\b[^>]*>[\s\S]*?<\/video>/gi, '[video]');
@@ -387,25 +390,63 @@ function openChart(ticker) {
 function closeChart() {}
 
 
+function renderMarkdownTableBlock(block = '') {
+    const rows = block.split('\n').map(l => l.trim()).filter(Boolean);
+    if (rows.length < 2) return '';
+
+    const header = rows[0];
+    const divider = rows[1];
+    if (!/^\|.*\|$/.test(header) || !/^\|[-:| ]+\|$/.test(divider)) return '';
+
+    const bodyRows = rows.slice(2).filter(r => /^\|.*\|$/.test(r));
+    const splitRow = (row) => row.slice(1, -1).split('|').map(c => c.trim());
+    const headerCells = splitRow(header);
+    if (!headerCells.length) return '';
+
+    const headHtml = `<tr>${headerCells.map(c => `<th style="border:1px solid #ddd;padding:6px 8px;background:#f7f7f7;text-align:left;">${c}</th>`).join('')}</tr>`;
+    const bodyHtml = bodyRows.map(r => {
+        const cells = splitRow(r);
+        return `<tr>${cells.map(c => `<td style="border:1px solid #ddd;padding:6px 8px;vertical-align:top;">${c}</td>`).join('')}</tr>`;
+    }).join('');
+
+    return `<div style="overflow-x:auto;margin:8px 0;"><table style="border-collapse:collapse;width:100%;font-size:12px;">${headHtml}${bodyHtml}</table></div>`;
+}
+
 function parseMedia(text) {
     if (!text) return '';
-    const lines = text.split('\n');
+
+    // Convert markdown tables to HTML tables first.
+    const withTables = text.replace(/(^|\n)(\|.+\|\n\|[-:| ]+\|(?:\n\|.*\|)*)/gmi, (m, p1, tableBlock) => {
+        const html = renderMarkdownTableBlock(tableBlock);
+        return p1 + (html || tableBlock);
+    });
+
+    const lines = withTables.split('\n');
     return lines.map(line => {
-        const trimmed = line.trim();
-        const ytId = extractYouTubeId(trimmed);
+        const mediaUrl = extractMediaUrlFromLine(line);
+        const ytId = extractYouTubeId(mediaUrl);
         if (ytId) {
-            return `<a href="https://www.youtube.com/watch?v=${ytId}" target="_blank" style="display:block;position:relative;margin:8px 0;border-radius:8px;overflow:hidden;text-decoration:none;">
-                <img src="https://img.youtube.com/vi/${ytId}/hqdefault.jpg" style="width:100%;display:block;border-radius:8px;" />
-                <div style="position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:64px;height:64px;background:rgba(0,0,0,0.7);border-radius:50%;display:flex;align-items:center;justify-content:center;">
-                    <div style="width:0;height:0;border-top:14px solid transparent;border-bottom:14px solid transparent;border-left:24px solid white;margin-left:4px;"></div>
-                </div>
-            </a>`;
+            const embedUrl = `https://www.youtube.com/embed/${ytId}?rel=0&modestbranding=1`;
+            return `<div style="position:relative;width:100%;padding-top:56.25%;margin:8px 0;border-radius:8px;overflow:hidden;">
+                <iframe
+                    src="${embedUrl}"
+                    title="YouTube video"
+                    loading="lazy"
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                    referrerpolicy="strict-origin-when-cross-origin"
+                    allowfullscreen
+                    style="position:absolute;inset:0;width:100%;height:100%;border:0;">
+                </iframe>
+            </div>`;
         }
-        if (isVideoUrl(trimmed)) {
-            return `<video src="${trimmed}" controls style="max-width:100%;height:auto;border-radius:8px;margin:8px 0;" preload="metadata"></video>`;
+        if (isVideoUrl(mediaUrl)) {
+            return `<video controls playsinline style="max-width:100%;height:auto;border-radius:8px;margin:8px 0;" preload="metadata">
+                <source src="${mediaUrl}">
+                <a href="${mediaUrl}" target="_blank" rel="noopener noreferrer">Open video</a>
+            </video>`;
         }
-        if (isImageUrl(trimmed)) {
-            return `<img src="${trimmed}" style="max-width:100%; height:auto; border-radius:8px; margin:8px 0;" loading="lazy" />`;
+        if (isImageUrl(mediaUrl)) {
+            return `<img src="${mediaUrl}" style="max-width:100%; height:auto; border-radius:8px; margin:8px 0;" loading="lazy" />`;
         }
         return line;
     }).join('\n');
@@ -434,10 +475,16 @@ function serializeNotes(editorEl) {
     html = html.replace(/<br\s*\/?>/gi, '\n');
     // Keep spaces but decode HTML entities properly
     html = html.replace(/&nbsp;/g, ' ');
-    // Don't strip leading newlines - preserve formatting
     const decoder = document.createElement('textarea');
     decoder.innerHTML = html;
-    return decoder.value;
+
+    // Normalize newline/whitespace noise from contenteditable wrappers.
+    return decoder.value
+        .replace(/\r\n?/g, '\n')
+        .split('\n')
+        .map(line => line.replace(/[ \t]+$/g, ''))
+        .join('\n')
+        .replace(/\n{3,}/g, '\n\n');
 }
 
 /** Notes popup */


### PR DESCRIPTION
## Summary
Improves notes UX so LLM-generated markdown is readable in-app without page reload hacks.

## Changes
- Adds markdown table rendering in notes popup (pipe table syntax -> HTML table).
- Adds markdown table compaction in row preview (`[table]`) to keep the table view concise.
- Improves media parsing by extracting URLs from markdown links, not just raw lines.
- Upgrades YouTube handling to inline embeds.
- Uses `<video><source></video>` with a direct fallback link for better playback compatibility.
- Normalizes whitespace when serializing notes to reduce random blank-line noise.

## Why
Targets issue #44 items around:
- "table markdown ?"
- "LLM generated stuff should be much shorter. Maybe a table view ?"
- lingering media playback/formatting friction in notes.

Fixes #44
