### PR TITLE
feat(mobile): notes swipe navigation + preview/edit UX improvements

### DIFF
--- a/src/github.js
+++ b/src/github.js
@@ -65,8 +65,8 @@ class GitHubClient {
         return res;
     }
 
-    async loadFile() {
-        const url = `${this.API_URL}/repos/${this.repoOwner}/${this.repoName}/contents/${this.filePath}?t=${Date.now()}`;
+    async loadFile(path = this.filePath) {
+        const url = `${this.API_URL}/repos/${this.repoOwner}/${this.repoName}/contents/${path}?t=${Date.now()}`;
         const res = await this._fetch(url);
         if (res.status === 404) return { exists: false, content: null };
         if (!res.ok) throw new Error(`GitHub API ${res.status}`);
@@ -91,10 +91,10 @@ class GitHubClient {
         return { exists: true, content, sha: data.sha };
     }
 
-    async saveFile(content, message = 'Update portfolio') {
+    async saveFile(content, message = 'Update portfolio', path = this.filePath) {
         // Get current SHA
-        const current = await this.loadFile();
-        const url = `${this.API_URL}/repos/${this.repoOwner}/${this.repoName}/contents/${this.filePath}`;
+        const current = await this.loadFile(path);
+        const url = `${this.API_URL}/repos/${this.repoOwner}/${this.repoName}/contents/${path}`;
         // Convert to base64 in chunks to avoid "Maximum call stack size exceeded"
         const bytes = new TextEncoder().encode(content);
         let binaryString = '';

--- a/src/index.html
+++ b/src/index.html
@@ -107,8 +107,9 @@
                 <button class="notes-popup-close minimal" id="notes-popup-close" title="Close">×</button>
                 
                 <!-- Rich editor with auto-embed -->
-                <div id="notes-edit-panel" class="notes-panel" style="flex:1; display:flex; flex-direction:column;">
-                    <div id="notes-editor" contenteditable="true" style="flex:1; min-height:200px; padding:12px; border:1px solid #ddd; border-radius:8px; background:white; overflow-y:auto; line-height:1.6; outline:none;" placeholder="Write your notes here..."></div>
+                <div id="notes-edit-panel" class="notes-panel" style="flex:1; display:flex; flex-direction:column; gap:10px;">
+                    <div id="notes-editor" contenteditable="true" style="flex:1; min-height:180px; padding:12px; border:1px solid #ddd; border-radius:8px; background:white; overflow-y:auto; line-height:1.6; outline:none;" placeholder="Write your notes here..."></div>
+                    <div id="notes-markdown-preview" style="min-height:120px; max-height:30vh; overflow:auto; border:1px solid #e5e7eb; border-radius:8px; background:#fafafa; padding:10px;"></div>
                 </div>
             </div>
         </div>
@@ -168,6 +169,7 @@
         </div>
     </div>
     <!-- Load modules in order with cache busting -->
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <script src="github.js?v=__BUILD_HASH__"></script>
     <script src="yahoo.js?v=__BUILD_HASH__"></script>
     <script src="portfolio.js?v=__BUILD_HASH__"></script>

--- a/src/index.html
+++ b/src/index.html
@@ -105,20 +105,25 @@
             <div class="notes-popup-content minimal">
                 <div class="notes-topbar" style="display:flex;align-items:center;gap:8px;">
                     <button id="notes-back-btn" class="btn-secondary" style="padding:6px 10px;">← Back</button>
+                    <button id="notes-sidebar-toggle" class="btn-secondary" style="padding:6px 10px;">☰ Stocks</button>
                     <button id="notes-prev-btn" class="btn-secondary" style="padding:6px 10px;">← Prev</button>
                     <button id="notes-next-btn" class="btn-secondary" style="padding:6px 10px;">Next →</button>
-                    <div id="notes-popup-stock" class="notes-popup-stock"></div>
                 </div>
                 <button class="notes-popup-close minimal" id="notes-popup-close" title="Close">×</button>
-                
-                <!-- Rich editor with auto-embed -->
-                <div id="notes-edit-panel" class="notes-panel" style="flex:1; display:flex; flex-direction:column; gap:10px;">
-                    <div style="display:flex; gap:8px; justify-content:flex-end;">
-                        <button id="notes-mode-preview" class="btn-secondary" style="padding:6px 10px;">Preview</button>
-                        <button id="notes-mode-edit" class="btn-secondary" style="padding:6px 10px;">Edit</button>
-                    </div>
-                    <div id="notes-editor" contenteditable="true" style="display:none; flex:1; min-height:180px; padding:12px; border:1px solid #ddd; border-radius:8px; background:white; overflow-y:auto; line-height:1.6; outline:none;" placeholder="Write your notes here..."></div>
-                    <div id="notes-markdown-preview" style="flex:1; min-height:180px; overflow:auto; border:1px solid #e5e7eb; border-radius:8px; background:#fafafa; padding:10px;"></div>
+
+                <div class="notes-split-layout">
+                    <aside id="notes-sidebar" class="notes-sidebar"></aside>
+                    <section id="notes-detail" class="notes-detail">
+                        <div id="notes-popup-stock" class="notes-popup-stock"></div>
+                        <div id="notes-edit-panel" class="notes-panel" style="flex:1; display:flex; flex-direction:column; gap:10px;">
+                            <div style="display:flex; gap:8px; justify-content:flex-end;">
+                                <button id="notes-mode-preview" class="btn-secondary" style="padding:6px 10px;">Preview</button>
+                                <button id="notes-mode-edit" class="btn-secondary" style="padding:6px 10px;">Edit</button>
+                            </div>
+                            <div id="notes-editor" contenteditable="true" style="display:none; flex:1; min-height:180px; padding:12px; border:1px solid #ddd; border-radius:8px; background:white; overflow-y:auto; line-height:1.6; outline:none;" placeholder="Write your notes here..."></div>
+                            <div id="notes-markdown-preview" style="flex:1; min-height:180px; overflow:auto; border:1px solid #e5e7eb; border-radius:8px; background:#fafafa; padding:10px;"></div>
+                        </div>
+                    </section>
                 </div>
             </div>
         </div>
@@ -169,6 +174,7 @@
                     </th>
                     <th>Notes</th>
                     <th>Current Price</th>
+                    <th>Market Cap</th>
                     <th id="sort-3m-return" style="cursor:pointer;">3M Return</th>
                     <th id="sort-cumret" style="cursor:pointer;">Cumulative Return</th>
                     <th style="width: 30px;"></th>

--- a/src/index.html
+++ b/src/index.html
@@ -127,10 +127,15 @@
                 </div>
                 <div class="modal-body">
                     <p style="margin-top:0;color:#666;font-size:13px;">Use this as the stock-analysis instruction block for OpenClaw/LLMs.</p>
-                    <textarea id="llm-guide-text" style="width:100%;height:62vh;resize:vertical;font-family:ui-monospace,Menlo,monospace;font-size:12px;line-height:1.45;padding:12px;border:1px solid #ddd;border-radius:8px;"></textarea>
+                    <div style="display:flex; gap:8px; justify-content:flex-end; margin-bottom:8px;">
+                        <button id="llm-mode-preview" class="btn-secondary">Preview</button>
+                        <button id="llm-mode-edit" class="btn-secondary">Edit</button>
+                    </div>
+                    <textarea id="llm-guide-text" style="display:none;width:100%;height:62vh;resize:vertical;font-family:ui-monospace,Menlo,monospace;font-size:12px;line-height:1.45;padding:12px;border:1px solid #ddd;border-radius:8px;"></textarea>
+                    <div id="llm-guide-preview" style="height:62vh;overflow:auto;border:1px solid #e5e7eb;border-radius:8px;background:#fafafa;padding:10px;"></div>
                     <div style="display:flex;gap:10px;justify-content:flex-end;margin-top:10px;">
                         <button id="llm-guide-copy" class="btn-secondary">Copy</button>
-                        <button id="llm-guide-save" class="btn-primary">Save locally</button>
+                        <button id="llm-guide-save" class="btn-primary">Save to GitHub</button>
                     </div>
                 </div>
             </div>

--- a/src/index.html
+++ b/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">

--- a/src/index.html
+++ b/src/index.html
@@ -103,7 +103,10 @@
         <!-- Notes Popup with Markdown & Image Support -->
         <div id="notes-popup-overlay" class="notes-popup-overlay">
             <div class="notes-popup-content minimal">
-                <div id="notes-popup-stock" class="notes-popup-stock"></div>
+                <div style="display:flex;align-items:center;gap:8px;">
+                    <button id="notes-back-btn" class="btn-secondary" style="padding:6px 10px;">← Back</button>
+                    <div id="notes-popup-stock" class="notes-popup-stock"></div>
+                </div>
                 <button class="notes-popup-close minimal" id="notes-popup-close" title="Close">×</button>
                 
                 <!-- Rich editor with auto-embed -->

--- a/src/index.html
+++ b/src/index.html
@@ -103,8 +103,10 @@
         <!-- Notes Popup with Markdown & Image Support -->
         <div id="notes-popup-overlay" class="notes-popup-overlay">
             <div class="notes-popup-content minimal">
-                <div style="display:flex;align-items:center;gap:8px;">
+                <div class="notes-topbar" style="display:flex;align-items:center;gap:8px;">
                     <button id="notes-back-btn" class="btn-secondary" style="padding:6px 10px;">← Back</button>
+                    <button id="notes-prev-btn" class="btn-secondary" style="padding:6px 10px;">← Prev</button>
+                    <button id="notes-next-btn" class="btn-secondary" style="padding:6px 10px;">Next →</button>
                     <div id="notes-popup-stock" class="notes-popup-stock"></div>
                 </div>
                 <button class="notes-popup-close minimal" id="notes-popup-close" title="Close">×</button>

--- a/src/index.html
+++ b/src/index.html
@@ -108,8 +108,12 @@
                 
                 <!-- Rich editor with auto-embed -->
                 <div id="notes-edit-panel" class="notes-panel" style="flex:1; display:flex; flex-direction:column; gap:10px;">
-                    <div id="notes-editor" contenteditable="true" style="flex:1; min-height:180px; padding:12px; border:1px solid #ddd; border-radius:8px; background:white; overflow-y:auto; line-height:1.6; outline:none;" placeholder="Write your notes here..."></div>
-                    <div id="notes-markdown-preview" style="min-height:120px; max-height:30vh; overflow:auto; border:1px solid #e5e7eb; border-radius:8px; background:#fafafa; padding:10px;"></div>
+                    <div style="display:flex; gap:8px; justify-content:flex-end;">
+                        <button id="notes-mode-preview" class="btn-secondary" style="padding:6px 10px;">Preview</button>
+                        <button id="notes-mode-edit" class="btn-secondary" style="padding:6px 10px;">Edit</button>
+                    </div>
+                    <div id="notes-editor" contenteditable="true" style="display:none; flex:1; min-height:180px; padding:12px; border:1px solid #ddd; border-radius:8px; background:white; overflow-y:auto; line-height:1.6; outline:none;" placeholder="Write your notes here..."></div>
+                    <div id="notes-markdown-preview" style="flex:1; min-height:180px; overflow:auto; border:1px solid #e5e7eb; border-radius:8px; background:#fafafa; padding:10px;"></div>
                 </div>
             </div>
         </div>

--- a/src/main.js
+++ b/src/main.js
@@ -16,6 +16,29 @@ function tryAutoLogin() {
 }
 
 const LLM_GUIDE_CACHE_KEY = 'llm_guide_markdown_v2';
+let llmMode = 'preview';
+
+function setLlmMode(mode) {
+    llmMode = mode;
+    const ta = document.getElementById('llm-guide-text');
+    const pv = document.getElementById('llm-guide-preview');
+    const bPrev = document.getElementById('llm-mode-preview');
+    const bEdit = document.getElementById('llm-mode-edit');
+    if (!ta || !pv) return;
+    const isPreview = mode === 'preview';
+    ta.style.display = isPreview ? 'none' : 'block';
+    pv.style.display = isPreview ? 'block' : 'none';
+    if (bPrev) bPrev.style.opacity = isPreview ? '1' : '0.7';
+    if (bEdit) bEdit.style.opacity = isPreview ? '0.7' : '1';
+}
+
+function updateLlmPreview() {
+    const ta = document.getElementById('llm-guide-text');
+    const pv = document.getElementById('llm-guide-preview');
+    if (!ta || !pv) return;
+    if (window.marked?.parse) pv.innerHTML = window.marked.parse(ta.value || '');
+    else pv.textContent = ta.value || '';
+}
 
 async function loadLlmPrompt() {
     const stored = localStorage.getItem(LLM_GUIDE_CACHE_KEY);
@@ -89,15 +112,25 @@ document.addEventListener('DOMContentLoaded', () => {
     // LLM guide modal
     const llmModal = document.getElementById('llm-guide-modal');
     const llmText = document.getElementById('llm-guide-text');
-    loadLlmPrompt().then(guide => { if (llmText) llmText.value = guide; });
+    loadLlmPrompt().then(guide => {
+        if (llmText) llmText.value = guide;
+        updateLlmPreview();
+        setLlmMode('preview');
+    });
 
     document.getElementById('llm-guide-btn')?.addEventListener('click', () => {
         if (!llmModal) return;
         llmModal.style.display = 'flex';
+        updateLlmPreview();
+        setLlmMode('preview');
     });
     document.getElementById('llm-guide-close')?.addEventListener('click', () => {
         if (llmModal) llmModal.style.display = 'none';
     });
+    document.getElementById('llm-mode-preview')?.addEventListener('click', () => setLlmMode('preview'));
+    document.getElementById('llm-mode-edit')?.addEventListener('click', () => setLlmMode('edit'));
+    llmText?.addEventListener('input', updateLlmPreview);
+
     document.getElementById('llm-guide-copy')?.addEventListener('click', async () => {
         try {
             await navigator.clipboard.writeText(llmText?.value || '');
@@ -106,9 +139,20 @@ document.addEventListener('DOMContentLoaded', () => {
             showStatus('Copy failed', 'error');
         }
     });
-    document.getElementById('llm-guide-save')?.addEventListener('click', () => {
-        localStorage.setItem(LLM_GUIDE_CACHE_KEY, llmText?.value || '');
-        showStatus('LLM instructions saved locally', 'success');
+    document.getElementById('llm-guide-save')?.addEventListener('click', async () => {
+        const content = llmText?.value || '';
+        localStorage.setItem(LLM_GUIDE_CACHE_KEY, content);
+        try {
+            if (!window.githubClient?.isAuthenticated || !window.githubClient.isAuthenticated()) {
+                showStatus('Connect GitHub first to save llm-prompt.md', 'error');
+                return;
+            }
+            await window.githubClient.saveFile(content, 'Update llm-prompt.md instructions', 'llm-prompt.md');
+            showStatus('LLM instructions saved to GitHub (llm-prompt.md)', 'success');
+        } catch (e) {
+            console.error(e);
+            showStatus('GitHub save failed, kept local draft', 'error');
+        }
     });
 
     // Add stock button → open modal

--- a/src/portfolio.js
+++ b/src/portfolio.js
@@ -99,7 +99,7 @@ function parseHtml(content) {
             labels: cells[3].textContent.split(',').map(l => l.trim()).filter(Boolean),
             notes: cells[4].textContent,
             rating: ratingMatch ? parseInt(ratingMatch[1]) : 0,
-            nowPrice: 'Loading...', cumulativeReturn: 'Calculating...', return3m: 'Loading...'
+            nowPrice: 'Loading...', cumulativeReturn: 'Calculating...', return3m: 'Loading...', marketCap: null
         };
     }).filter(Boolean);
 
@@ -174,7 +174,7 @@ async function updateAllPrices() {
     // Kick off all price+return requests; onEach fires as each resolves
     await api.fetchBatchPriceAndReturn(
         portfolio.map(s => s.ticker.toUpperCase()),
-        async (ticker, { price, ret3m }) => {
+        async (ticker, { price, ret3m, marketCap }) => {
             const idx = portfolio.findIndex(s => s.ticker.toUpperCase() === ticker);
             if (idx === -1) return;
             const stock = portfolio[idx];
@@ -182,6 +182,7 @@ async function updateAllPrices() {
 
             stock.nowPrice         = price != null ? Number(price).toFixed(2) : 'N/A';
             stock.return3m         = ret3m != null ? ret3m : 'N/A';
+            stock.marketCap        = marketCap ?? stock.marketCap ?? null;
             stock.cumulativeReturn = (price != null && hist != null)
                 ? (((price - hist) / hist) * 100).toFixed(2) : 'N/A';
 
@@ -207,7 +208,7 @@ async function addStock(ticker, name, date, initialLabel = '') {
     const stock = {
         ticker: t, name: name || t, date: discoveryDate,
         labels: normalizedInitialLabel ? [normalizedInitialLabel] : [], notes: '', rating: 0,
-        nowPrice: '...', cumulativeReturn: '...', return3m: '...', loading: true
+        nowPrice: '...', cumulativeReturn: '...', return3m: '...', marketCap: null, loading: true
     };
     portfolio.push(stock);
     markChanged();
@@ -215,12 +216,13 @@ async function addStock(ticker, name, date, initialLabel = '') {
     showStatus(`Adding ${t}\u2026`, 'info');
 
     try {
-        const [{ price, ret3m }, hist] = await Promise.all([
+        const [{ price, ret3m, marketCap }, hist] = await Promise.all([
             api.fetchPriceAndReturn(t),
             api.fetchHistoricalPrice(t, discoveryDate)
         ]);
         stock.nowPrice = price != null ? price.toFixed(2) : 'N/A';
         stock.return3m = ret3m || 'N/A';
+        stock.marketCap = marketCap ?? stock.marketCap ?? null;
         stock.cumulativeReturn = (price != null && hist != null)
             ? (((price - hist) / hist) * 100).toFixed(2) : 'N/A';
     } catch (err) {
@@ -256,11 +258,12 @@ async function updateDate(idx, date) {
     markChanged();
     const api = window.MarketData;
     try {
-        const [{ price }, hist] = await Promise.all([
+        const [{ price, marketCap }, hist] = await Promise.all([
             api.fetchPriceAndReturn(portfolio[idx].ticker),
             api.fetchHistoricalPrice(portfolio[idx].ticker, date)
         ]);
         portfolio[idx].nowPrice = price ? price.toFixed(2) : 'N/A';
+        portfolio[idx].marketCap = marketCap ?? portfolio[idx].marketCap ?? null;
         portfolio[idx].cumulativeReturn = (hist && price) ? (((price - hist) / hist) * 100).toFixed(2) : 'N/A';
         if (window.updatePriceCells) window.updatePriceCells(portfolio[idx]);
     } catch {}

--- a/src/styles.css
+++ b/src/styles.css
@@ -255,16 +255,17 @@ tr.unrated-row { background: #fff5f5 !important; }
     .form-row { flex-direction: column; }
     .notes-popup-content.minimal {
         width: 99%;
-        height: calc(95vh - env(safe-area-inset-top, 0px));
+        height: 95vh;
         padding: 10px;
-        padding-top: calc(10px + env(safe-area-inset-top, 0px));
+        padding-top: 10px;
     }
     .notes-topbar {
         position: sticky;
         top: 0;
         background: #fff;
-        z-index: 3;
-        padding-top: calc(env(safe-area-inset-top, 0px) + 6px);
+        z-index: 10;
+        /* hard fallback + safe-area for browsers that don't report env() reliably */
+        padding-top: max(42px, calc(env(safe-area-inset-top, 0px) + 6px));
         padding-bottom: 6px;
     }
     .notes-topbar #notes-back-btn,

--- a/src/styles.css
+++ b/src/styles.css
@@ -293,7 +293,8 @@ tr.unrated-row { background: #fff5f5 !important; }
 @media (max-width: 480px) {
     body { padding: 0.125em; }
     th, td { padding: 6px 4px; font-size: 0.75em; }
-    th:nth-child(7), td:nth-child(7) { display: none; }
+    /* keep Market Cap visible; hide 3M Return on very small screens */
+    th:nth-child(8), td:nth-child(8) { display: none; }
 }
 
 /* Add stock floating button */

--- a/src/styles.css
+++ b/src/styles.css
@@ -243,6 +243,13 @@ tr.unrated-row { background: #fff5f5 !important; }
 .notes-toolbar { display: flex; align-items: center; gap: 10px; margin-bottom: 8px; padding: 8px; background: #f5f5f5; border-radius: 4px; }
 .toolbar-hint { font-size: 11px; color: #999; margin-left: auto; }
 .notes-panel { flex: 1; display: flex; flex-direction: column; min-height: 200px; }
+.notes-split-layout { display: grid; grid-template-columns: 240px 1fr; gap: 10px; flex: 1; min-height: 0; }
+.notes-sidebar { border:1px solid #e5e7eb; border-radius:8px; background:#fafafa; overflow:auto; padding:6px; }
+.notes-sidebar-item { display:block; width:100%; text-align:left; padding:8px; border:none; background:transparent; border-radius:6px; cursor:pointer; font-size:13px; }
+.notes-sidebar-item:hover { background:#eef2ff; }
+.notes-sidebar-item.active { background:#dbeafe; color:#1d4ed8; font-weight:700; }
+.notes-detail { min-width: 0; display:flex; flex-direction:column; gap:8px; }
+.notes-toolbar-row { display:grid; grid-template-columns: 1.5fr 0.9fr 1fr 0.8fr 0.9fr 0.9fr 0.9fr; gap:8px; align-items:center; padding:8px; border:1px solid #e5e7eb; border-radius:8px; background:#f8fafc; font-size:12px; }
 
 /* Mobile */
 @media (max-width: 768px) {
@@ -270,11 +277,14 @@ tr.unrated-row { background: #fff5f5 !important; }
         border-bottom: 1px solid #e5e7eb;
     }
     .notes-topbar #notes-back-btn,
+    .notes-topbar #notes-sidebar-toggle,
     .notes-topbar #notes-prev-btn,
     .notes-topbar #notes-next-btn { font-size: 12px; padding: 6px 8px; }
-    .notes-popup-stock { font-size: 20px; gap: 6px; }
-    .notes-popup-stock-main { gap: 6px; flex-wrap: wrap; }
-    .notes-popup-stock-metric { font-size: 12px; }
+    .notes-split-layout { grid-template-columns: 1fr; }
+    .notes-sidebar { display: none; }
+    .notes-popup-content.minimal.sidebar-open .notes-sidebar { display: block; max-height: 28vh; }
+    .notes-popup-stock { font-size: 16px; gap: 6px; }
+    .notes-toolbar-row { grid-template-columns: 1fr 1fr; font-size: 11px; gap:6px; }
     #notes-mode-preview, #notes-mode-edit { font-size: 12px; padding: 6px 10px; }
     #notes-markdown-preview { min-height: 220px; }
     .github-connected { flex-direction: column; gap: 10px; text-align: center; }

--- a/src/styles.css
+++ b/src/styles.css
@@ -174,7 +174,12 @@ button { padding: 10px 15px; border: none; border-radius: 4px; cursor: pointer; 
     .actions-section { gap: 8px; margin: 12px 0; }
     .actions-section .btn-primary,
     .actions-section .btn-secondary { width: 100%; justify-content: center; }
-    th, td { padding: 8px 8px; font-size: 0.9rem; }
+    table { min-width: 680px; }
+    th, td { padding: 7px 6px; font-size: 0.85rem; }
+    .notes-popup-content.minimal { width: 99%; height: 94vh; padding: 10px; }
+    .notes-popup-stock { font-size: 22px; margin-bottom: 8px; }
+    .notes-popup-stock-metric { font-size: 14px; }
+    .notes-popup-arrows-hint { font-size: 12px; }
 }
 
 /* GitHub */
@@ -231,6 +236,9 @@ tr.unrated-row { background: #fff5f5 !important; }
 .notes-popup-arrows-hint { margin-left:auto; color:#9ca3af; font-size:17px; white-space:nowrap; font-weight:700; }
 .notes-popup-close.minimal { background: none; border: none; font-size: 20px; color: #bbb; cursor: pointer; position: absolute; top: 10px; right: 14px; z-index: 2; }
 .notes-popup-close:hover { color: #666; }
+#notes-markdown-preview table { border-collapse: collapse; width: 100%; font-size: 12px; }
+#notes-markdown-preview th, #notes-markdown-preview td { border: 1px solid #d1d5db; padding: 6px; text-align: left; }
+#notes-markdown-preview th { background: #f3f4f6; }
 .notes-toolbar { display: flex; align-items: center; gap: 10px; margin-bottom: 8px; padding: 8px; background: #f5f5f5; border-radius: 4px; }
 .toolbar-hint { font-size: 11px; color: #999; margin-left: auto; }
 .notes-panel { flex: 1; display: flex; flex-direction: column; min-height: 200px; }

--- a/src/styles.css
+++ b/src/styles.css
@@ -229,7 +229,8 @@ tr.unrated-row { background: #fff5f5 !important; }
 .notes-popup-overlay.show { opacity: 1; visibility: visible; }
 .notes-popup-content.minimal { border-radius: 12px; box-shadow: 0 4px 24px rgba(0,0,0,0.15); padding: 16px 20px; max-width: 1600px; width: 97%; height: 92vh; display: flex; flex-direction: column; background: #fff; position: relative; }
 .notes-popup-overlay.show .notes-popup-content { transform: scale(1) translateY(0); }
-.notes-popup-stock { font-size: 48px; font-weight: 900; color: #111827; margin-bottom: 14px; display:flex; align-items:center; justify-content:space-between; gap:14px; width:100%; }
+.notes-topbar { margin-bottom: 8px; }
+.notes-popup-stock { font-size: 48px; font-weight: 900; color: #111827; margin-bottom: 0; display:flex; align-items:center; justify-content:space-between; gap:14px; width:100%; }
 .notes-popup-stock-main { display:flex; align-items:center; gap:16px; min-width:0; overflow:hidden; }
 .notes-popup-stock-main > span:first-child { white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
 .notes-popup-stock-metric { font-size:24px; color:#4b5563; font-weight:800; white-space:nowrap; }
@@ -253,10 +254,13 @@ tr.unrated-row { background: #fff5f5 !important; }
     .modal-content { width: 95%; }
     .form-row { flex-direction: column; }
     .notes-popup-content.minimal { width: 99%; height: 95vh; padding: 10px; }
-    .notes-popup-stock { font-size: 24px; gap: 8px; }
-    .notes-popup-stock-main { gap: 8px; }
-    .notes-popup-stock-metric { font-size: 13px; }
-    .notes-popup-arrows-hint { font-size: 11px; }
+    .notes-topbar { position: sticky; top: 0; background: #fff; z-index: 3; padding-bottom: 6px; }
+    .notes-topbar #notes-back-btn,
+    .notes-topbar #notes-prev-btn,
+    .notes-topbar #notes-next-btn { font-size: 12px; padding: 6px 8px; }
+    .notes-popup-stock { font-size: 20px; gap: 6px; }
+    .notes-popup-stock-main { gap: 6px; flex-wrap: wrap; }
+    .notes-popup-stock-metric { font-size: 12px; }
     #notes-mode-preview, #notes-mode-edit { font-size: 12px; padding: 6px 10px; }
     #notes-markdown-preview { min-height: 220px; }
     .github-connected { flex-direction: column; gap: 10px; text-align: center; }

--- a/src/styles.css
+++ b/src/styles.css
@@ -235,7 +235,7 @@ tr.unrated-row { background: #fff5f5 !important; }
 .notes-popup-stock-main > span:first-child { white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
 .notes-popup-stock-metric { font-size:24px; color:#4b5563; font-weight:800; white-space:nowrap; }
 .notes-popup-arrows-hint { margin-left:auto; color:#9ca3af; font-size:17px; white-space:nowrap; font-weight:700; }
-.notes-popup-close.minimal { background: none; border: none; font-size: 20px; color: #bbb; cursor: pointer; position: absolute; top: 10px; right: 14px; z-index: 2; }
+.notes-popup-close.minimal { background: none; border: none; font-size: 20px; color: #bbb; cursor: pointer; position: absolute; top: calc(8px + env(safe-area-inset-top, 0px)); right: 10px; z-index: 25; }
 .notes-popup-close:hover { color: #666; }
 #notes-markdown-preview table { border-collapse: collapse; width: 100%; font-size: 12px; }
 #notes-markdown-preview th, #notes-markdown-preview td { border: 1px solid #d1d5db; padding: 6px; text-align: left; }
@@ -257,16 +257,17 @@ tr.unrated-row { background: #fff5f5 !important; }
         width: 99%;
         height: 95vh;
         padding: 10px;
-        padding-top: 10px;
+        padding-top: calc(64px + env(safe-area-inset-top, 0px));
     }
     .notes-topbar {
-        position: sticky;
+        position: absolute;
+        left: 0;
+        right: 0;
         top: 0;
         background: #fff;
-        z-index: 10;
-        /* hard fallback + safe-area for browsers that don't report env() reliably */
-        padding-top: max(42px, calc(env(safe-area-inset-top, 0px) + 6px));
-        padding-bottom: 6px;
+        z-index: 20;
+        padding: calc(8px + env(safe-area-inset-top, 0px)) 10px 6px 10px;
+        border-bottom: 1px solid #e5e7eb;
     }
     .notes-topbar #notes-back-btn,
     .notes-topbar #notes-prev-btn,

--- a/src/styles.css
+++ b/src/styles.css
@@ -252,7 +252,13 @@ tr.unrated-row { background: #fff5f5 !important; }
     .actions-section { flex-direction: column; align-items: stretch; gap: 10px; }
     .modal-content { width: 95%; }
     .form-row { flex-direction: column; }
-    .notes-popup-content.minimal { width: 97%; height: 92vh; }
+    .notes-popup-content.minimal { width: 99%; height: 95vh; padding: 10px; }
+    .notes-popup-stock { font-size: 24px; gap: 8px; }
+    .notes-popup-stock-main { gap: 8px; }
+    .notes-popup-stock-metric { font-size: 13px; }
+    .notes-popup-arrows-hint { font-size: 11px; }
+    #notes-mode-preview, #notes-mode-edit { font-size: 12px; padding: 6px 10px; }
+    #notes-markdown-preview { min-height: 220px; }
     .github-connected { flex-direction: column; gap: 10px; text-align: center; }
     .api-key-bar { position: static; justify-content: flex-end; margin-bottom: 12px; }
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -253,8 +253,20 @@ tr.unrated-row { background: #fff5f5 !important; }
     .actions-section { flex-direction: column; align-items: stretch; gap: 10px; }
     .modal-content { width: 95%; }
     .form-row { flex-direction: column; }
-    .notes-popup-content.minimal { width: 99%; height: 95vh; padding: 10px; }
-    .notes-topbar { position: sticky; top: 0; background: #fff; z-index: 3; padding-bottom: 6px; }
+    .notes-popup-content.minimal {
+        width: 99%;
+        height: calc(95vh - env(safe-area-inset-top, 0px));
+        padding: 10px;
+        padding-top: calc(10px + env(safe-area-inset-top, 0px));
+    }
+    .notes-topbar {
+        position: sticky;
+        top: 0;
+        background: #fff;
+        z-index: 3;
+        padding-top: calc(env(safe-area-inset-top, 0px) + 6px);
+        padding-bottom: 6px;
+    }
     .notes-topbar #notes-back-btn,
     .notes-topbar #notes-prev-btn,
     .notes-topbar #notes-next-btn { font-size: 12px; padding: 6px 8px; }

--- a/src/ui.js
+++ b/src/ui.js
@@ -68,6 +68,15 @@ function formatDate(dateStr) {
     return { formatted, timeAgo };
 }
 
+function formatMarketCap(val) {
+    const n = Number(val);
+    if (!Number.isFinite(n) || n <= 0) return 'N/A';
+    if (n >= 1e12) return `$${(n / 1e12).toFixed(2)}T`;
+    if (n >= 1e9) return `$${(n / 1e9).toFixed(2)}B`;
+    if (n >= 1e6) return `$${(n / 1e6).toFixed(1)}M`;
+    return `$${Math.round(n).toLocaleString()}`;
+}
+
 function colorReturn(val) {
     if (!val || val === 'N/A' || val === 'Error' || val === '...') return `<span style="color:#666;display:inline-block;min-width:50px">${val}</span>`;
     const n = parseFloat(val);
@@ -302,7 +311,7 @@ function updatePortfolioTable() {
     if (unrated.length > 0) {
         const tr = document.createElement('tr');
         const show = window.Portfolio.showZeroStarStocks;
-        tr.innerHTML = `<td colspan="9" style="text-align:center;background:#f5f5f5;cursor:pointer;padding:10px;border-top:2px solid #ddd;color:#666;font-size:14px;">${show ? '▼' : '▶'} ${unrated.length} unrated stock${unrated.length > 1 ? 's' : ''}</td>`;
+        tr.innerHTML = `<td colspan="10" style="text-align:center;background:#f5f5f5;cursor:pointer;padding:10px;border-top:2px solid #ddd;color:#666;font-size:14px;">${show ? '▼' : '▶'} ${unrated.length} unrated stock${unrated.length > 1 ? 's' : ''}</td>`;
         tr.addEventListener('click', () => { window.Portfolio.showZeroStarStocks = !show; updatePortfolioTable(); });
         tbody.appendChild(tr);
         if (show) unrated.forEach(s => renderRow(tbody, s));
@@ -354,6 +363,7 @@ function renderRow(tbody, stock) {
         : '';
     const notesShort = getNotesPreview(stock.notes);
     const priceDisplay = stock.loading ? '...' : (stock.nowPrice !== 'N/A' && stock.nowPrice !== 'Loading...' ? '$' + stock.nowPrice : stock.nowPrice);
+    const mcapDisplay = formatMarketCap(stock.marketCap);
 
     tr.innerHTML = `
         <td style="text-align:center">${stars}</td>
@@ -362,6 +372,7 @@ function renderRow(tbody, stock) {
         <td style="text-align:center"><div class="labels-box" style="min-width:80px;padding:4px">${labels}${addLabelDropdown}</div></td>
         <td style="text-align:center"><span class="notes-btn" style="cursor:pointer;padding:8px;background:#f9f9f9;color:#666;border-radius:3px;display:inline-block;min-width:80px">${notesShort}</span></td>
         <td class="price-cell" style="text-align:right;font-variant-numeric:tabular-nums;min-width:80px">${priceDisplay}</td>
+        <td class="mcap-cell" style="text-align:right;font-variant-numeric:tabular-nums;min-width:82px">${mcapDisplay}</td>
         <td class="return3m-cell" style="text-align:right;font-variant-numeric:tabular-nums;min-width:60px">${colorReturn(stock.return3m)}</td>
         <td class="cumret-cell" style="text-align:right;font-variant-numeric:tabular-nums;min-width:60px">${colorReturn(stock.cumulativeReturn)}</td>
         <td style="text-align:center;width:30px"><button class="rm-stock" style="background:none;color:#ccc;border:none;cursor:pointer;font-size:16px">×</button></td>`;
@@ -516,19 +527,24 @@ function getVisibleTableStockIndices() {
 
 function renderNotesHeader(idx) {
     const stock = window.Portfolio.data[idx];
-    const title = stock ? `${stock.ticker} — ${stock.name || ''}` : '';
+    const d = formatDate(stock?.date || '');
     const price = (stock?.nowPrice && stock.nowPrice !== 'N/A' && stock.nowPrice !== 'Loading...' && stock.nowPrice !== '...')
         ? `$${stock.nowPrice}`
         : (stock?.nowPrice || 'N/A');
+    const mcap = formatMarketCap(stock?.marketCap);
     const ret3m = colorReturn(stock?.return3m || 'N/A');
     const total = colorReturn(stock?.cumulativeReturn || 'N/A');
+    const labels = (stock?.labels || []).join(', ') || '-';
     document.getElementById('notes-popup-stock').innerHTML = `
-        <span class="notes-popup-stock-main" style="display:flex;align-items:center;gap:14px;width:100%;">
-            <span style="flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">${title}</span>
-            <span class="notes-popup-stock-metric" style="font-weight:800;font-size:1.05em;color:#111;background:#ffe082;padding:2px 8px;border-radius:999px;">${price}</span>
-            <span class="notes-popup-stock-metric">3M: ${ret3m}</span>
-            <span class="notes-popup-stock-metric">Total: ${total}</span>
-        </span>`;
+        <div class="notes-toolbar-row">
+            <div><b>${stock?.ticker || ''}</b><div style="font-size:11px;color:#6b7280">${stock?.name || ''}</div></div>
+            <div>${d.formatted || '-'}</div>
+            <div>${labels}</div>
+            <div>${price}</div>
+            <div>${mcap}</div>
+            <div>3M ${ret3m}</div>
+            <div>Total ${total}</div>
+        </div>`;
 
     // If modal navigation reveals a stock that never entered viewport, load its price now.
     if (stock?.ticker && (stock.nowPrice === 'Loading...' || stock.nowPrice === '...') && typeof loadPriceLazy === 'function') {
@@ -550,13 +566,41 @@ function updateNotesMarkdownPreview() {
     }
 }
 
+function renderNotesSidebar() {
+    const sidebar = document.getElementById('notes-sidebar');
+    if (!sidebar) return;
+    const visible = getVisibleTableStockIndices();
+    sidebar.innerHTML = '';
+    visible.forEach(i => {
+        const s = window.Portfolio.data[i];
+        const btn = document.createElement('button');
+        btn.className = 'notes-sidebar-item' + (i === currentNotesStockIndex ? ' active' : '');
+        btn.textContent = `${s.ticker} — ${s.name || ''}`;
+        btn.onclick = () => {
+            currentNotesStockIndex = i;
+            renderNotesHeader(i);
+            const editor = document.getElementById('notes-editor');
+            if (editor) {
+                editor.innerHTML = parseMedia(s.notes || '');
+                prepareMediaInEditor(editor);
+                updateNotesMarkdownPreview();
+            }
+            renderNotesSidebar();
+            document.querySelector('.notes-popup-content.minimal')?.classList.remove('sidebar-open');
+        };
+        sidebar.appendChild(btn);
+    });
+}
+
 function openNotesPopup(idx) {
     currentNotesStockIndex = idx;
     document.getElementById('notes-back-btn')?.addEventListener('click', closeNotesPopup, { once: true });
     const prevBtn = document.getElementById('notes-prev-btn');
     const nextBtn = document.getElementById('notes-next-btn');
+    const sidebarToggle = document.getElementById('notes-sidebar-toggle');
     if (prevBtn) prevBtn.onclick = () => navigateNotesPopup(-1);
     if (nextBtn) nextBtn.onclick = () => navigateNotesPopup(1);
+    if (sidebarToggle) sidebarToggle.onclick = () => document.querySelector('.notes-popup-content.minimal')?.classList.toggle('sidebar-open');
     notesEditorDirty = false;
     const stock = window.Portfolio.data[idx];
     const overlay = document.getElementById('notes-popup-overlay');
@@ -573,6 +617,7 @@ function openNotesPopup(idx) {
     if (modePreviewBtn) modePreviewBtn.onclick = () => setNotesMode('preview');
     if (modeEditBtn) modeEditBtn.onclick = () => setNotesMode('edit');
     setNotesMode('preview');
+    renderNotesSidebar();
 
     if (panel) {
         const handleSwipeEnd = (endX) => {
@@ -619,6 +664,7 @@ function navigateNotesPopup(step) {
 
     const stock = window.Portfolio.data[currentNotesStockIndex];
     renderNotesHeader(currentNotesStockIndex);
+    renderNotesSidebar();
     if (editor) {
         editor.innerHTML = parseMedia(stock.notes || '');
         prepareMediaInEditor(editor);
@@ -767,10 +813,12 @@ function updatePriceCells(stock) {
 
     const priceDisplay = stock.loading ? '...' : (stock.nowPrice !== 'N/A' && stock.nowPrice !== 'Loading...' ? '$' + stock.nowPrice : stock.nowPrice);
     const priceCell = tr.querySelector('.price-cell');
+    const mcapCell = tr.querySelector('.mcap-cell');
     const ret3mCell = tr.querySelector('.return3m-cell');
     const cumretCell = tr.querySelector('.cumret-cell');
 
     if (priceCell) priceCell.innerHTML = priceDisplay;
+    if (mcapCell) mcapCell.innerHTML = formatMarketCap(stock.marketCap);
     if (ret3mCell) ret3mCell.innerHTML = colorReturn(stock.return3m);
     if (cumretCell) cumretCell.innerHTML = colorReturn(stock.cumulativeReturn);
 }
@@ -816,13 +864,14 @@ async function loadPriceLazy(ticker) {
     if (!stock || stock.nowPrice !== 'Loading...') return;
     
     try {
-        const [{ price, ret3m }, hist] = await Promise.all([
+        const [{ price, ret3m, marketCap }, hist] = await Promise.all([
             api.fetchPriceAndReturn(ticker),
             api.fetchHistoricalPrice(ticker, stock.date)
         ]);
         
         stock.nowPrice = price != null ? Number(price).toFixed(2) : 'N/A';
         stock.return3m = ret3m != null ? ret3m : 'N/A';
+        stock.marketCap = marketCap ?? stock.marketCap ?? null;
         stock.cumulativeReturn = (price != null && hist != null)
             ? (((price - hist) / hist) * 100).toFixed(2) : 'N/A';
         

--- a/src/ui.js
+++ b/src/ui.js
@@ -524,6 +524,18 @@ function renderNotesHeader(idx) {
     }
 }
 
+function updateNotesMarkdownPreview() {
+    const editor = document.getElementById('notes-editor');
+    const preview = document.getElementById('notes-markdown-preview');
+    if (!editor || !preview) return;
+    const md = serializeNotes(editor) || '';
+    if (window.marked?.parse) {
+        preview.innerHTML = window.marked.parse(md);
+    } else {
+        preview.textContent = md;
+    }
+}
+
 function openNotesPopup(idx) {
     currentNotesStockIndex = idx;
     notesEditorDirty = false;
@@ -533,7 +545,8 @@ function openNotesPopup(idx) {
     const editor = document.getElementById('notes-editor');
     editor.innerHTML = parseMedia(stock.notes || '');
     prepareMediaInEditor(editor);
-    editor.oninput = () => { notesEditorDirty = true; };
+    updateNotesMarkdownPreview();
+    editor.oninput = () => { notesEditorDirty = true; updateNotesMarkdownPreview(); };
     overlay.style.display = 'flex';
     setTimeout(() => { overlay.classList.add('show'); editor.focus(); }, 10);
 }
@@ -558,6 +571,7 @@ function navigateNotesPopup(step) {
     if (editor) {
         editor.innerHTML = parseMedia(stock.notes || '');
         prepareMediaInEditor(editor);
+        updateNotesMarkdownPreview();
         editor.scrollTop = 0;
         editor.focus();
     }

--- a/src/ui.js
+++ b/src/ui.js
@@ -4,6 +4,21 @@
 let tableUpdateTimeout = null;
 let currentNotesStockIndex = null;
 let notesEditorDirty = false;
+let notesMode = 'preview';
+
+function setNotesMode(mode) {
+    notesMode = mode;
+    const editor = document.getElementById('notes-editor');
+    const preview = document.getElementById('notes-markdown-preview');
+    const btnPrev = document.getElementById('notes-mode-preview');
+    const btnEdit = document.getElementById('notes-mode-edit');
+    if (!editor || !preview) return;
+    const isPreview = mode === 'preview';
+    editor.style.display = isPreview ? 'none' : 'block';
+    preview.style.display = isPreview ? 'block' : 'none';
+    if (btnPrev) btnPrev.style.opacity = isPreview ? '1' : '0.7';
+    if (btnEdit) btnEdit.style.opacity = isPreview ? '0.7' : '1';
+}
 const NOTES_PREVIEW_MAX_CHARS = 100;
 const LABEL_TAB_COOKIE = 'labelTab';
 
@@ -547,8 +562,15 @@ function openNotesPopup(idx) {
     prepareMediaInEditor(editor);
     updateNotesMarkdownPreview();
     editor.oninput = () => { notesEditorDirty = true; updateNotesMarkdownPreview(); };
+
+    const modePreviewBtn = document.getElementById('notes-mode-preview');
+    const modeEditBtn = document.getElementById('notes-mode-edit');
+    if (modePreviewBtn) modePreviewBtn.onclick = () => setNotesMode('preview');
+    if (modeEditBtn) modeEditBtn.onclick = () => setNotesMode('edit');
+    setNotesMode('preview');
+
     overlay.style.display = 'flex';
-    setTimeout(() => { overlay.classList.add('show'); editor.focus(); }, 10);
+    setTimeout(() => { overlay.classList.add('show'); }, 10);
 }
 
 function navigateNotesPopup(step) {

--- a/src/ui.js
+++ b/src/ui.js
@@ -5,6 +5,7 @@ let tableUpdateTimeout = null;
 let currentNotesStockIndex = null;
 let notesEditorDirty = false;
 let notesMode = 'preview';
+let notesTouchStartX = null;
 
 function setNotesMode(mode) {
     notesMode = mode;
@@ -556,6 +557,7 @@ function openNotesPopup(idx) {
     notesEditorDirty = false;
     const stock = window.Portfolio.data[idx];
     const overlay = document.getElementById('notes-popup-overlay');
+    const panel = document.querySelector('.notes-popup-content.minimal');
     renderNotesHeader(idx);
     const editor = document.getElementById('notes-editor');
     editor.innerHTML = parseMedia(stock.notes || '');
@@ -568,6 +570,30 @@ function openNotesPopup(idx) {
     if (modePreviewBtn) modePreviewBtn.onclick = () => setNotesMode('preview');
     if (modeEditBtn) modeEditBtn.onclick = () => setNotesMode('edit');
     setNotesMode('preview');
+
+    if (panel) {
+        const handleSwipeEnd = (endX) => {
+            if (notesTouchStartX == null) return;
+            const dx = endX - notesTouchStartX;
+            notesTouchStartX = null;
+            if (Math.abs(dx) < 50) return;
+            if (dx < 0) navigateNotesPopup(1);   // swipe left -> next
+            else navigateNotesPopup(-1);         // swipe right -> previous
+        };
+
+        panel.ontouchstart = (e) => {
+            if (!e.touches || !e.touches.length) return;
+            notesTouchStartX = e.touches[0].clientX;
+        };
+        panel.ontouchend = (e) => {
+            if (!e.changedTouches || !e.changedTouches.length) return;
+            handleSwipeEnd(e.changedTouches[0].clientX);
+        };
+
+        // pointer fallback (also testable in desktop automation)
+        panel.onpointerdown = (e) => { notesTouchStartX = e.clientX; };
+        panel.onpointerup = (e) => { handleSwipeEnd(e.clientX); };
+    }
 
     overlay.style.display = 'flex';
     setTimeout(() => { overlay.classList.add('show'); }, 10);

--- a/src/ui.js
+++ b/src/ui.js
@@ -554,6 +554,7 @@ function updateNotesMarkdownPreview() {
 
 function openNotesPopup(idx) {
     currentNotesStockIndex = idx;
+    document.getElementById('notes-back-btn')?.addEventListener('click', closeNotesPopup, { once: true });
     notesEditorDirty = false;
     const stock = window.Portfolio.data[idx];
     const overlay = document.getElementById('notes-popup-overlay');

--- a/src/ui.js
+++ b/src/ui.js
@@ -522,15 +522,13 @@ function renderNotesHeader(idx) {
         : (stock?.nowPrice || 'N/A');
     const ret3m = colorReturn(stock?.return3m || 'N/A');
     const total = colorReturn(stock?.cumulativeReturn || 'N/A');
-    const hint = '←/→/↑/↓';
     document.getElementById('notes-popup-stock').innerHTML = `
         <span class="notes-popup-stock-main" style="display:flex;align-items:center;gap:14px;width:100%;">
             <span style="flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">${title}</span>
             <span class="notes-popup-stock-metric" style="font-weight:800;font-size:1.05em;color:#111;background:#ffe082;padding:2px 8px;border-radius:999px;">${price}</span>
             <span class="notes-popup-stock-metric">3M: ${ret3m}</span>
             <span class="notes-popup-stock-metric">Total: ${total}</span>
-        </span>
-        <span class="notes-popup-arrows-hint" style="margin-left:auto;">${hint}</span>`;
+        </span>`;
 
     // If modal navigation reveals a stock that never entered viewport, load its price now.
     if (stock?.ticker && (stock.nowPrice === 'Loading...' || stock.nowPrice === '...') && typeof loadPriceLazy === 'function') {
@@ -555,6 +553,10 @@ function updateNotesMarkdownPreview() {
 function openNotesPopup(idx) {
     currentNotesStockIndex = idx;
     document.getElementById('notes-back-btn')?.addEventListener('click', closeNotesPopup, { once: true });
+    const prevBtn = document.getElementById('notes-prev-btn');
+    const nextBtn = document.getElementById('notes-next-btn');
+    if (prevBtn) prevBtn.onclick = () => navigateNotesPopup(-1);
+    if (nextBtn) nextBtn.onclick = () => navigateNotesPopup(1);
     notesEditorDirty = false;
     const stock = window.Portfolio.data[idx];
     const overlay = document.getElementById('notes-popup-overlay');

--- a/src/yahoo.js
+++ b/src/yahoo.js
@@ -85,6 +85,12 @@ async function yfFetch(ticker, period1, period2) {
     return data;
 }
 
+async function yfFetchQuote(ticker) {
+    const url = `${YF_BASE}/v7/finance/quote?symbols=${encodeURIComponent(ticker)}`;
+    const data = await fetchJsonDirect(url, `quote:${ticker}`);
+    return data?.quoteResponse?.result?.[0] || null;
+}
+
 /**
  * Single Yahoo call: 94-day chart → current price + 3-month return.
  */
@@ -98,13 +104,16 @@ async function yfPriceAndReturn(ticker) {
 
     const now = Math.floor(Date.now() / 1000);
     const p1  = now - 94 * 86400;
-    const json   = await yfFetch(ticker, p1, now);
+    const [json, quote] = await Promise.all([
+        yfFetch(ticker, p1, now),
+        yfFetchQuote(ticker).catch(() => null)
+    ]);
     const meta   = json?.chart?.result?.[0]?.meta ?? {};
     const closes = json?.chart?.result?.[0]?.indicators?.quote?.[0]?.close ?? [];
     const valid  = closes.filter(c => c != null);
 
-    const price = meta.regularMarketPrice ?? meta.chartPreviousClose ?? (valid.length ? valid[valid.length - 1] : null);
-    const marketCap = (typeof meta.marketCap === 'number') ? meta.marketCap : null;
+    const price = quote?.regularMarketPrice ?? meta.regularMarketPrice ?? meta.chartPreviousClose ?? (valid.length ? valid[valid.length - 1] : null);
+    const marketCap = (typeof quote?.marketCap === 'number') ? quote.marketCap : ((typeof meta.marketCap === 'number') ? meta.marketCap : null);
     let ret3m = null;
     if (valid.length >= 2) {
         const first = valid[0], last = valid[valid.length - 1];

--- a/src/yahoo.js
+++ b/src/yahoo.js
@@ -104,13 +104,14 @@ async function yfPriceAndReturn(ticker) {
     const valid  = closes.filter(c => c != null);
 
     const price = meta.regularMarketPrice ?? meta.chartPreviousClose ?? (valid.length ? valid[valid.length - 1] : null);
+    const marketCap = (typeof meta.marketCap === 'number') ? meta.marketCap : null;
     let ret3m = null;
     if (valid.length >= 2) {
         const first = valid[0], last = valid[valid.length - 1];
         if (first > 0) ret3m = (((last - first) / first) * 100).toFixed(2);
     }
 
-    const entry = { price: typeof price === 'number' ? price : null, ret3m };
+    const entry = { price: typeof price === 'number' ? price : null, ret3m, marketCap };
     mdLog('quote computed', { ticker, price: entry.price, ret3m: entry.ret3m, bars: valid.length });
     setCache(ck, entry);
     return entry;


### PR DESCRIPTION
This PR contains the mobile/notes UX changes moved off main:\n\n- markdown preview/edit toggle for notes (preview default)\n- explicit back button in notes popup\n- swipe left/right between notes\n- small-screen readability/layout improvements\n- llm-instructions modal preview/edit + GitHub save support\n\nMain has been reverted; this PR is the clean review path.